### PR TITLE
Removing Lukes Cards

### DIFF
--- a/pages/updates.tsx
+++ b/pages/updates.tsx
@@ -10,6 +10,11 @@ const Updates: NextPage<Props> = () => {
   const updates = [
     {
       title: "Removing Store",
+      date: "Feb 24, 2024",
+      description:"Luke's Cards domain no longer exists."
+    },
+    {
+      title: "Removing Store",
       date: "Feb 22, 2024",
       description:"North of Exile Games no longer sells MTG singles."
     },

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -377,12 +377,6 @@ const websites: Website[] = [
     shopify: true
   },
   {
-    name: "Luke's Cards",
-    code: 'lukescards',
-    image: '',
-    shopify: true
-  },
-  {
     name: 'Mecha Games',
     code: 'mechagames',
     image: '',


### PR DESCRIPTION
Domain No Longer Exists: https://www.lukescards.com/

I'm assuming the store doesn't exist or they just forgot to renew their Go Daddy domain name.