### PR TITLE
Added Discord to Nav Bar and Advanced Search Fixes

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -34,6 +34,11 @@ export default function Navbar({}: Props) {
       href: '/wishlist',
       current: currentPath === '/wishlist'
     },
+    {
+      name: 'Discord',
+      href: 'https://discord.gg/EnKKHxSq75',
+      target: '_blank'
+    },
     // { name: 'About', href: '/about', current: currentPath === '/about' },
     // { name: 'Updates', href: '/updates', current: currentPath === '/updates' },
     // ...(isAuthenticated ? [{ name: 'Wishlists', href: '/wishlist', current: currentPath === '/wishlist' }] : []),

--- a/pages/advancedsearch.tsx
+++ b/pages/advancedsearch.tsx
@@ -181,6 +181,17 @@ export default function AdvancedSearch({}: Props) {
             type="text"
             placeholder="Card Base Name"
             defaultValue={''}
+            onKeyDown={(e) => {
+              if (e.key == 'Enter') {
+                if (searchRef.current) {
+                  updateAdvnacedSearchTextBoxValue(searchRef.current.value);
+                }
+                if (numberRef.current) {
+                  updateNumberText(Number(numberRef.current.value));
+                }
+                fetchAdvancedSearchResults();
+              }
+            }}
           ></Input>
 
           <Button

--- a/stores/advancedStore.ts
+++ b/stores/advancedStore.ts
@@ -2557,7 +2557,7 @@ export const advancedUseStore = create<State>((set, get) => ({
         `${process.env.NEXT_PUBLIC_SEARCH_URL}/advanced`,
         {
           cardCategory: get().selectedCardCategory,
-          cardName: get().advnacedSearchTextBoxValue,
+          cardName: get().advnacedSearchTextBoxValue.trim(),
           website: get().selectedWebsiteList,
           condition: get().selectedConditionsList,
           foil: get().selectedFoilList,

--- a/stores/advancedStore.ts
+++ b/stores/advancedStore.ts
@@ -139,6 +139,10 @@ const foilList: Filter[] = [
     abbreviation: 'Foil'
   },
   {
+    name: 'Confetti',
+    abbreviation: 'Confetti'
+  },
+  {
     name: 'Etched',
     abbreviation: 'Etched'
   },


### PR DESCRIPTION
**Added Discord non expiring link to navbar**

**Advanced Search Fixes**

- input tag removes leading and trailing white spaces
- user can hit enter on their keyboard in the text box to search instead of hitting the search button
- added the confetti foil type that I forgot to put in originally
