### PR TITLE
Added About page to mobile nav and fixed broken image

### DIFF
--- a/components/NavbarNew.tsx
+++ b/components/NavbarNew.tsx
@@ -146,6 +146,12 @@ export default function NavbarNew() {
               Discord
             </Button>
           </Link>
+          {/* About */}
+          <Link className="" href="/about">
+            <Button variant="ghost" className="block w-full text-left text-sm">
+              About
+            </Button>
+          </Link>
           {!isAuthenticated && (
             <Link href="/signin">
               <Button

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -25,7 +25,7 @@ const About: NextPage<Props> = () => {
                     Gathering players, letting you search for MTG singles across
                     70 Canadian websites. It allows users to efficiently search
                     multiple websites simultaneously, aggregating results in a
-                    single, convenient location. We are excited to continuously
+                    single convenient location. We are excited to continuously
                     improve the service and welcome any suggestions and feed
                     back in our official{' '}
                     <a

--- a/pages/card-guide/index.tsx
+++ b/pages/card-guide/index.tsx
@@ -12,7 +12,7 @@ const BuyersGuide: NextPage<Props> = () => {
       link: '/card-guide/condition',
       description:
         'The condition of a card can significantly affect its value. Players can save alot of money when constructing their decks by purchasing cards in lower condtions.',
-      image: '/buyers-guide-images/5-condition-page.jpg',
+      image: '/buyers-guide-images/5-condition-page.JPG',
       imageAlt: 'Condition Guide Image'
     },
     {

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import axiosInstance from '@/utils/axiosWrapper';
 import { toast } from 'sonner';
+
 export interface SingleSearchResult {
   name: string;
   link: string;


### PR DESCRIPTION
Fixing a broken image on the card guide index page (please double check that the images load fine).
Added the about page as an option in the mobile nav bar.