### PR TITLE
removed leading and trailing spaces in single search and UI bug fixes

### DIFF
--- a/pages/wishlist/index.tsx
+++ b/pages/wishlist/index.tsx
@@ -185,13 +185,26 @@ const Wishlist: NextPage<Props> = () => {
               {wishlists &&
                 wishlists.map((wishlist) => (
                   <Link
-                    href={`/wishlist/${wishlist.id}`}
-                    as={`/wishlist/${wishlist.id}`}
+                    href={
+                      editWishlistId === wishlist.id
+                        ? ''
+                        : `/wishlist/${wishlist.id}`
+                    }
+                    as={
+                      editWishlistId === wishlist.id
+                        ? ''
+                        : `/wishlist/${wishlist.id}`
+                    }
                     key={wishlist.id}
+                    className="cursor-default"
                   >
                     <Card
                       key={wishlist.id}
-                      className="cursor-pointer text-left transition-shadow duration-300 ease-in-out hover:border-zinc-500 hover:shadow-lg"
+                      className={
+                        editWishlistId === wishlist.id
+                          ? 'cursor-default text-left transition-shadow duration-300 ease-in-out hover:border-zinc-500 hover:shadow-lg'
+                          : 'cursor-pointer text-left transition-shadow duration-300 ease-in-out hover:border-zinc-500 hover:shadow-lg'
+                      }
                     >
                       <CardHeader className="flex flex-row items-center justify-between gap-4">
                         {editWishlistId === wishlist.id ? (
@@ -209,6 +222,7 @@ const Wishlist: NextPage<Props> = () => {
                             e.preventDefault();
                             toggleEditMode(wishlist.id);
                           }}
+                          className="cursor-pointer"
                         />
                       </CardHeader>
                       <CardContent>

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -777,7 +777,7 @@ export const useStore = create<State>((set, get) => ({
     const response = await axiosInstance.post(
       `${process.env.NEXT_PUBLIC_SEARCH_URL}/single`,
       {
-        cardName: searchInput
+        cardName: searchInput.trim()
       }
     );
 


### PR DESCRIPTION
Bug fix for user "TheStrider"
- removed leading and trailing spaces in single search.
- fixed a ui bug when editing wishlists from the /wishlist page. If you are in edit mode and click anywhere like the text box to edit the name it would redirect to the href. I also made some adjustments like remove the pointer cursor when they're in edit mode.
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/0ed5f079-98af-4a57-aa83-5036bc1d32e3)
