### PR TITLE
Single Search Adjustment, Reset Filter Bug Fix,  Advanced Filter Dropdown UX Adjustment

### DIFF
--- a/components/advanced-search/advanced-catalog-row.tsx
+++ b/components/advanced-search/advanced-catalog-row.tsx
@@ -77,11 +77,13 @@ export default function SingleCatalogRow({ cardData }: Props) {
 
             <div className=" flex  flex-wrap font-serif text-xs font-semibold">
               {cardData.website in promoMap && (
-                <div className="mb-1 mr-1 max-w-fit rounded-sm bg-gradient-to-tl from-rose-600 to-rose-800 px-1 text-center align-middle text-xs ">
-                  {`-${(
-                    (1 - promoMap[cardData.website]['discount']) *
-                    100
-                  ).toFixed(0)}% ${promoMap[cardData.website]['promoCode']}`}
+                <div className="mb-1 mr-1 max-w-fit rounded-sm bg-gradient-to-tl from-rose-600 to-rose-800 px-1 text-center align-middle lowercase">
+                  <p>
+                    {`-${(
+                      (1 - promoMap[cardData.website]['discount']) *
+                      100
+                    ).toFixed(0)}% ${promoMap[cardData.website]['promoCode']}`}
+                  </p>
                 </div>
               )}
               {cardData.promo == true && (

--- a/components/advanced-search/advanced-filter-dropdown.tsx
+++ b/components/advanced-search/advanced-filter-dropdown.tsx
@@ -28,28 +28,6 @@ type Props = {
   selectCount: number;
   toggle(field: string, category: string): void;
 };
-const frameworks = [
-  {
-    value: 'next.js',
-    label: 'Next.js'
-  },
-  {
-    value: 'sveltekit',
-    label: 'SvelteKit'
-  },
-  {
-    value: 'nuxt.js',
-    label: 'Nuxt.js'
-  },
-  {
-    value: 'remix',
-    label: 'Remix'
-  },
-  {
-    value: 'astro',
-    label: 'Astro'
-  }
-];
 
 export function FilterDropdownBox(props: Props) {
   const [open, setOpen] = React.useState(false);
@@ -95,7 +73,10 @@ export function FilterDropdownBox(props: Props) {
         </PopoverTrigger>
         <PopoverContent className="max-h-[--radix-popover-content-available-height] w-[--radix-popover-trigger-width]">
           <Command>
-            <CommandInput placeholder={`Search ${props.label}...`} />
+            <CommandInput
+              tabIndex={-1}
+              placeholder={`Search ${props.label}...`}
+            />
             <ScrollArea className=" h-80">
               <CommandEmpty>No {props.label} found.</CommandEmpty>
               <CommandGroup>
@@ -111,7 +92,6 @@ export function FilterDropdownBox(props: Props) {
                           // [state.abbreviation]: e.target.checked
                         });
                         props.toggle(state.abbreviation, props.label);
-                        // setOpen(false);
                       }}
                     >
                       <div className="flex">

--- a/components/single-search/single-grid-item.tsx
+++ b/components/single-search/single-grid-item.tsx
@@ -45,7 +45,7 @@ export default function SingleCatalogCard({ cardData }: Props) {
           {findWebsiteNameByCode(cardData.website)}
         </p>
         <p className="text-sm">{cardData.condition}</p>
-        <p className="text-sm font-bold">${cardData.price}</p>
+        <p className="text-sm font-bold">${cardData.priceBeforeDiscount}</p>
       </CardContent>
       <div className="flex-grow"></div>
       <CardFooter>
@@ -56,7 +56,9 @@ export default function SingleCatalogCard({ cardData }: Props) {
           className="w-full"
         >
           <Button
-            onClick={() => handleBuyClick(cardData.link, cardData.price)}
+            onClick={() =>
+              handleBuyClick(cardData.link, cardData.priceBeforeDiscount)
+            }
             className="w-full"
           >
             Buy

--- a/components/single-search/single-list-item.tsx
+++ b/components/single-search/single-list-item.tsx
@@ -42,7 +42,9 @@ export default function SingleCatalogRow({ cardData }: Props) {
           </div>
           <div className="col-span-4 mt-2 hidden sm:grid">
             <div className="flex flex-col items-end">
-              <div className="text-lg font-bold">${cardData.price}</div>
+              <div className="text-lg font-bold">
+                ${cardData.priceBeforeDiscount}
+              </div>
               <div className="flex flex-row space-x-2">
                 {cardData.foil && (
                   <div className="text-sm font-extrabold text-pink-500">

--- a/components/single-search/single-list-item.tsx
+++ b/components/single-search/single-list-item.tsx
@@ -61,7 +61,9 @@ export default function SingleCatalogRow({ cardData }: Props) {
                 className="w-full"
               >
                 <Button
-                  onClick={() => handleBuyClick(cardData.link, cardData.price)}
+                  onClick={() =>
+                    handleBuyClick(cardData.link, cardData.priceBeforeDiscount)
+                  }
                   className="w-full"
                 >
                   Buy

--- a/components/single-search/single-table.tsx
+++ b/components/single-search/single-table.tsx
@@ -49,7 +49,7 @@ const SingleResultsTable = (props: Props) => {
             <TableCell className="capitalize">{cardData.set}</TableCell>
             <TableCell>{findWebsiteNameByCode(cardData.website)}</TableCell>
             <TableCell>{cardData.condition}</TableCell>
-            <TableCell>{cardData.price}</TableCell>
+            <TableCell>{cardData.priceBeforeDiscount}</TableCell>
             <TableCell>
               <Link
                 href={cardData.link}
@@ -58,7 +58,9 @@ const SingleResultsTable = (props: Props) => {
                 className="w-full"
               >
                 <Button
-                  onClick={() => handleBuyClick(cardData.link, cardData.price)}
+                  onClick={() =>
+                    handleBuyClick(cardData.link, cardData.priceBeforeDiscount)
+                  }
                   className="w-full"
                 >
                   Buy

--- a/stores/advancedStore.ts
+++ b/stores/advancedStore.ts
@@ -48,8 +48,6 @@ export interface AdvancedSearchResult {
   goldenStampedSeries: boolean;
 }
 
-// const setList: Filter[] = [];
-
 const shopifyOnlySites = useStore.getState().websites.filter(function (item) {
   return item.shopify == true;
 });
@@ -413,6 +411,8 @@ export const advancedUseStore = create<State>((set, get) => ({
       artSeriesChecked: false,
       goldenStampedChecked: false,
       numberChecked: false,
+      promoPackChecked: false,
+      alternateArtJapaneseChecked: false,
       cardNumber: 0
     });
   },


### PR DESCRIPTION
- Single Search was using the price after discount. I swapped them with the price before discount until we want to implement the promo code badges.

**Single Search Result**
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/cf67b6f4-744d-4cf6-a780-1786c2095742)

**Advanced Search Result**
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/34c7081a-57f6-405e-9b2d-ee8b07d88759)

- Reset Filter now properly deselects all enabled filtered options in advanced search. (Specifically the Promo Pack and Japanese Alternate Art Toggles)
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/1897579b-f716-4f34-b50f-d3978f00a785)

- UX Adjustment to the advanced-filter-dropdown component. Clicking the dropdown would auto focus the search input and auto toggle mobile virtual keyboards which take up half the screen. Added 1 line of code that makes it so it doesn't auto focus by default.
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/0b5cad85-12b4-45bd-a85b-9c125b15e50f)
