### PR TITLE
Single Search, Multi Search, Advanced Search Trigger

### DIFF
--- a/components/autofill-searchbox.tsx
+++ b/components/autofill-searchbox.tsx
@@ -1,11 +1,14 @@
+import ReactGA from 'react-ga4';
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Input } from './ui/input';
 import { Search } from 'lucide-react';
 import { useDebounceCallback } from 'usehooks-ts';
+import { handleQuerySingleCard } from '@/utils/analytics';
 
 type Props = {
   searchFunction(searchText: string): void;
   setSearchInput(searchText: string): void;
+  searchType: string;
   tcg: string;
   searchInput: string;
   autocompleteEndpoint: string;
@@ -170,6 +173,13 @@ export default function SingleSearchbox(props: Props) {
           <button
             type="submit"
             className="absolute inset-y-0 right-0 flex cursor-pointer items-center pr-3 text-primary"
+            onClick={() => {
+              handleQuerySingleCard(
+                props.searchInput,
+                props.tcg,
+                props.searchType
+              );
+            }}
           >
             <Search size={15} />
           </button>

--- a/components/single-search/multitcg-searchbox.tsx
+++ b/components/single-search/multitcg-searchbox.tsx
@@ -38,6 +38,7 @@ const MultiTcgSearchbox = (props: Props) => {
         </SelectContent>
       </Select>
       <SingleSearchbox
+        searchType={'single'}
         searchFunction={fetchCards}
         setSearchInput={setSearchInput}
         searchInput={searchInput}

--- a/components/single-search/multitcg-searchbox.tsx
+++ b/components/single-search/multitcg-searchbox.tsx
@@ -13,7 +13,9 @@ import useSingleStore from '@/stores/singleSearchStore';
 
 import type { Tcgs } from '@/types/index';
 
-type Props = {};
+type Props = {
+  searchType: string;
+};
 
 const MultiTcgSearchbox = (props: Props) => {
   const { fetchCards, searchInput, setSearchInput, tcg, setTcg } =
@@ -38,7 +40,7 @@ const MultiTcgSearchbox = (props: Props) => {
         </SelectContent>
       </Select>
       <SingleSearchbox
-        searchType={'single'}
+        searchType={props.searchType}
         searchFunction={fetchCards}
         setSearchInput={setSearchInput}
         searchInput={searchInput}

--- a/pages/advancedsearch.tsx
+++ b/pages/advancedsearch.tsx
@@ -154,6 +154,7 @@ export default function AdvancedSearch({}: Props) {
           {/*Container 2 - Search Bar & Show Filters Button*/}
           <div className="flex items-center gap-2">
             <SingleSearchbox
+              searchType={'advanced'}
               searchFunction={fetchAdvancedSearchResults}
               setSearchInput={setAdvancedSearchInput}
               searchInput={advancedSearchInput}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,7 +35,7 @@ const Home: NextPage<Props> = ({}: Props) => {
         <div className="flex w-full flex-col justify-center gap-8 text-center">
           {!searchStarted && <Homebanner />}
           {adsEnabled && <PoweredBy size="small" />}
-          <MultiTcgSearchbox />
+          <MultiTcgSearchbox searchType={'single'} />
 
           {loading && (
             <div className="flex items-center justify-center pt-5">

--- a/pages/multisearch/index.tsx
+++ b/pages/multisearch/index.tsx
@@ -294,7 +294,7 @@ const SearchView = ({
   setTcg: (value: Tcgs) => void;
   searchInput: string;
   setSearchInput: (value: string) => void;
-  handleSubmit: () => void;
+  handleSubmit: (tcg: string) => void;
   websites: any[];
   selectedWebsites: any[];
   onWebsiteSelect: (value: any) => void;
@@ -343,15 +343,7 @@ const SearchView = ({
       />
       <Button
         onClick={() => {
-          handleSubmit;
-          const cardNames = searchInput
-            .split('\n')
-            .map((name) => name.trim())
-            .filter((name) => name.length > 0);
-          console.log(cardNames);
-          cardNames.forEach((card) => {
-            handleQuerySingleCard(card, tcg, 'multi');
-          });
+          handleSubmit(tcg);
         }}
         disabled={searchInput.length === 0 || loading}
       >

--- a/pages/multisearch/index.tsx
+++ b/pages/multisearch/index.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/table';
 import BackToTopButton from '@/components/ui/back-to-top-btn';
 import PoweredBy from '@/components/powered-by';
+import { handleQuerySingleCard } from '@/utils/analytics';
 
 type Props = {};
 
@@ -341,7 +342,17 @@ const SearchView = ({
         onChange={(e) => setSearchInput(e.target.value)}
       />
       <Button
-        onClick={handleSubmit}
+        onClick={() => {
+          handleSubmit;
+          const cardNames = searchInput
+            .split('\n')
+            .map((name) => name.trim())
+            .filter((name) => name.length > 0);
+          console.log(cardNames);
+          cardNames.forEach((card) => {
+            handleQuerySingleCard(card, tcg, 'multi');
+          });
+        }}
         disabled={searchInput.length === 0 || loading}
       >
         {loading ? (

--- a/stores/multiSearchStore.ts
+++ b/stores/multiSearchStore.ts
@@ -2,6 +2,7 @@ import { WebsiteMapping } from '@/types/website';
 import { create } from 'zustand';
 import axiosInstance from '@/utils/axiosWrapper';
 import type { Tcgs, MultiSearchProduct, Product } from '@/types';
+import { handleQuerySingleCard } from '@/utils/analytics';
 
 type MultiSearchState = {
   mode: 'search' | 'results';
@@ -16,7 +17,7 @@ type MultiSearchState = {
   };
   setMode: (mode: 'search' | 'results') => void;
   selectVariant: (key: string, product: Product) => void;
-  handleSubmit: () => void;
+  handleSubmit: (tcg: string) => void;
   setSearchInput: (value: string) => void;
   setTcg: (value: Tcgs) => void;
   onWebsiteSelect: (value: WebsiteMapping) => void;
@@ -45,7 +46,7 @@ const useMultiSearchStore = create<MultiSearchState>((set, get) => ({
   setMode: (mode: 'search' | 'results') => {
     set({ mode });
   },
-  handleSubmit: async () => {
+  handleSubmit: async (tcg) => {
     set({ loading: true });
     set({ searchQuery: get().searchInput });
 
@@ -56,7 +57,9 @@ const useMultiSearchStore = create<MultiSearchState>((set, get) => ({
         .searchInput.split('\n')
         .map((name) => name.trim())
         .filter((name) => name.length > 0);
-
+      cardNames.forEach((card) => {
+        handleQuerySingleCard(card, tcg, 'multi');
+      });
       // JSON encode the array and then URL encode it
       const encodedNames = encodeURIComponent(JSON.stringify(cardNames));
 

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -52,3 +52,17 @@ export const handleAdClick = (
     url: url
   });
 };
+
+export const handleQuerySingleCard = (
+  searchTerm: string,
+  tradingCardGame: string,
+  searchTool: string
+) => {
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event: 'search',
+    search_term: searchTerm,
+    tcg: tradingCardGame,
+    search_tool: searchTool
+  });
+};


### PR DESCRIPTION
Added existing search event/search click trigger from tag manager to capture single search and advanced search queries.

I just pass in searchType = {single | advanced} as a prop in the MultiTcgSearchbox since advanced search and single search both use the same component which gets passed down into the handleQuerySingleCard function in utils\analytics.ts.

**Files Affected:**
- pages/index.tsx
- pages/multisearch/index.tsx
- pages/advancedsearch.tsx
- components/single-search/multitcg-searchbox.tsx
- components/autofill-searchbox.tsx
- utils/analytics.ts
- stores/multiSearchStore.ts



**Examples Search Event Triggering In Preview Mode**

![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/c46fad64-e530-4d8f-9f81-00cd6d865df4)

![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/aefd7ffa-d0a5-4696-8571-9e3811f0b22c)

![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/f15c091d-6b3d-4405-b6e6-6cdb34806748)

