### PR TITLE
SNAP-127 Adding Crystal Commerce Stores to Advanced Page

### DIFF
--- a/pages/advancedsearch.tsx
+++ b/pages/advancedsearch.tsx
@@ -73,7 +73,7 @@ export default function AdvancedSearch({}: Props) {
     fetchAdvancedSearchResults
   } = advancedUseStore();
 
-  const { initWebsiteInformation, websitesAdvanced } = useStore();
+  const { initWebsiteInformation, websites } = useStore();
 
   const [showFilters, setShowFilters] = React.useState(false);
 
@@ -182,7 +182,7 @@ export default function AdvancedSearch({}: Props) {
               <div className="mb-4">
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                   <FilterDropdownBox
-                    option={websitesAdvanced.map((obj) => {
+                    option={websites.map((obj) => {
                       return { name: obj.name, abbreviation: obj.code };
                     })}
                     selectedList={selectedWebsiteList}

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -72,12 +72,11 @@ export const useStore = create<State>((set, get) => ({
       );
       let data = response.data;
       set({ websites: data.websiteList });
-      // let data = response.data.websiteList.filter(
-      //   (website: Website) => website.backend == 'shopify'
-      // );
+
       set({
         websitesAdvanced: data.websiteList.filter(
-          (website: Website) => website.backend == 'shopify'
+          (website: Website) =>
+            website.backend == 'shopify' || website.backend == 'crystalcommerce'
         )
       });
       let tempMap: PromoMap = {};

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -40,13 +40,11 @@ export type MultiSearchCardState = {
 };
 
 const websites: Website[] = [];
-const websitesAdvanced: Website[] = [];
-const websiteList: Filter[] = [];
+
 const promoMap: PromoMap = {};
 
 type State = {
   websites: Website[];
-  websitesAdvanced: Website[];
   promoMap: PromoMap;
   getWebsiteNameByCode: (code: string) => string;
 
@@ -59,7 +57,6 @@ export const useStore = create<State>((set, get) => ({
   },
 
   websites: websites,
-  websitesAdvanced: websitesAdvanced,
   promoMap: promoMap,
 
   initWebsiteInformation: async () => {
@@ -72,13 +69,6 @@ export const useStore = create<State>((set, get) => ({
       );
       let data = response.data;
       set({ websites: data.websiteList });
-
-      set({
-        websitesAdvanced: data.websiteList.filter(
-          (website: Website) =>
-            website.backend == 'shopify' || website.backend == 'crystalcommerce'
-        )
-      });
       let tempMap: PromoMap = {};
       for (const website of data.websiteList) {
         if (website['promoCode'] !== null) {


### PR DESCRIPTION
Purpose: Add Crystal Commerce to the websites options in advanced search.

**Files Updated**
- stores/store.ts

Note: After I get f2f and conduct commerce done, everythings going to switch to the catalog endpoint and then I'll be able to plug and play the row, card, and grid search results. After I do that I'll probably look to remove the advanced search page and integrate it all on the home page

**Screenshot of a conduct commerce website populating in the sets dropdown**
![image](https://github.com/bryceeppler/snapcaster-client/assets/95643389/2e6dabaa-59c1-4a0d-840d-6fbe3fb08bd5)
