### PR TITLE
bug fixes and adding ripple foil in advanced mtg

### DIFF
--- a/components/single-search/single-list-item.tsx
+++ b/components/single-search/single-list-item.tsx
@@ -18,6 +18,8 @@ export default function SingleCatalogRow({ cardData, promo, tcg }: Props) {
 
   const findWebsiteNameByCode = (code: string): string => {
     const website = websites.find((website) => website.code === code);
+    console.log(websites);
+
     return website ? website.name : 'Website not found';
   };
 

--- a/stores/advancedStore.ts
+++ b/stores/advancedStore.ts
@@ -163,6 +163,10 @@ const foilList: Filter[] = [
   {
     name: 'Raised',
     abbreviation: 'raised'
+  },
+  {
+    name: 'Ripple',
+    abbreviation: 'ripple'
   }
 ];
 

--- a/stores/singleSearchStore.ts
+++ b/stores/singleSearchStore.ts
@@ -82,7 +82,7 @@ const useSingleStore = create<SingleSearchState>((set, get) => ({
       const response = await axiosInstance.get(
         `${process.env.NEXT_PUBLIC_CATALOG_URL}/api/v1/search/?tcg=${
           get().tcg
-        }&name=${encodeURIComponent(get().searchInput)}`
+        }&name=${encodeURIComponent(get().searchInput.trim())}`
       );
       set({ searchQuery: get().searchInput });
       set({


### PR DESCRIPTION
**Purpose:**
- Add Ripple Foil as an option in mtg advanced. This was introduced in MH3 this past June.
-  Single Search wasn't trimming leading and trailing white spaces leading to messed up single search queries if there were any of the white spaces. I added the trim() function to the fetch function in the singleSearchStore.ts file.
- Remove a random console.log in the code that shouldn't be there.

**Affected Files:**
- _components/single-search/single-list-item.tsx_
- _stores/advancedStore.ts_
- _stores/singleSearchStore.ts_