### PR TITLE
change website code to website slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024-07-15
+
+### Changed
+
+- Changed all references to website.code to website.slug to match new database schema
+
 ## 2024-07-09
 
 ### Added

--- a/components/advanced-search/advanced-catalog-row.tsx
+++ b/components/advanced-search/advanced-catalog-row.tsx
@@ -43,7 +43,7 @@ export default function SingleCatalogRow({ cardData, tcg }: Props) {
   };
 
   const findWebsiteNameByCode = (code: string): string => {
-    const website = websites.find((website) => website.code === code);
+    const website = websites.find((website) => website.slug === code);
     return website ? website.name : 'Website not found';
   };
 

--- a/components/multi-search/multi-website-combobox.tsx
+++ b/components/multi-search/multi-website-combobox.tsx
@@ -33,7 +33,7 @@ export function WebsiteCombobox({
   const [open, setOpen] = React.useState(false);
 
   const isWebsiteSelected = (website: WebsiteMapping) =>
-    selectedWebsites.some((selected) => selected.code === website.code);
+    selectedWebsites.some((selected) => selected.slug === website.slug);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -62,7 +62,7 @@ export function WebsiteCombobox({
                 <div className="pr-2">
                   {websites.map((website) => (
                     <CommandItem
-                      key={website.code}
+                      key={website.slug}
                       value={website.name}
                       onSelect={(currentValue) => {
                         onWebsiteSelect(website);

--- a/components/single-search/single-grid-item.tsx
+++ b/components/single-search/single-grid-item.tsx
@@ -21,8 +21,8 @@ import { handleBuyClick } from '../../utils/analytics';
 export default function SingleCatalogCard({ cardData, tcg, promo }: Props) {
   const { websites } = useStore();
 
-  const findWebsiteNameByCode = (code: string): string => {
-    const website = websites.find((website) => website.code === code);
+  const findWebsiteNameByCode = (slug: string): string => {
+    const website = websites.find((website) => website.slug === slug);
     return website ? website.name : 'Website not found';
   };
 

--- a/components/single-search/single-list-item.tsx
+++ b/components/single-search/single-list-item.tsx
@@ -16,8 +16,8 @@ import CardImage from '../ui/card-image';
 export default function SingleCatalogRow({ cardData, promo, tcg }: Props) {
   const { websites } = useStore();
 
-  const findWebsiteNameByCode = (code: string): string => {
-    const website = websites.find((website) => website.code === code);
+  const findWebsiteNameByCode = (slug: string): string => {
+    const website = websites.find((website) => website.slug === slug);
     console.log(websites);
 
     return website ? website.name : 'Website not found';

--- a/components/single-search/single-table.tsx
+++ b/components/single-search/single-table.tsx
@@ -18,8 +18,8 @@ type Props = {
 const SingleResultsTable = (props: Props) => {
   const { websites } = useStore();
 
-  const findWebsiteNameByCode = (code: string): string => {
-    const website = websites.find((website) => website.code === code);
+  const findWebsiteNameByCode = (slug: string): string => {
+    const website = websites.find((website) => website.slug === slug);
     return website ? website.name : 'Website not found';
   };
 

--- a/pages/advancedsearch.tsx
+++ b/pages/advancedsearch.tsx
@@ -179,7 +179,7 @@ export default function AdvancedSearch({}: Props) {
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                 <FilterDropdownBox
                   option={websites.map((obj) => {
-                    return { name: obj.name, abbreviation: obj.code };
+                    return { name: obj.name, abbreviation: obj.slug };
                   })}
                   selectedList={selectedWebsiteList}
                   selectCount={selectedWebsiteCount}

--- a/pages/multisearch/index.tsx
+++ b/pages/multisearch/index.tsx
@@ -520,7 +520,7 @@ const SearchView = ({
         <WebsiteCombobox
           websites={websites.map((website) => ({
             name: website.name,
-            code: website.code
+            slug: website.slug
           }))}
           selectedWebsites={selectedWebsites}
           onWebsiteSelect={onWebsiteSelect}

--- a/stores/globalStore.ts
+++ b/stores/globalStore.ts
@@ -34,7 +34,7 @@ const useGlobalStore = create<GlobalState>((set, get) => ({
     set({ ads });
   },
   getWebsiteName: (websiteCode: string) => {
-    const website = get().websites.find((w) => w.code === websiteCode);
+    const website = get().websites.find((w) => w.slug === websiteCode);
     return website ? website.name : '';
   },
   fetchWebsites: async () => {

--- a/stores/multiSearchStore.ts
+++ b/stores/multiSearchStore.ts
@@ -121,7 +121,7 @@ const useMultiSearchStore = create<MultiSearchState>((set, get) => ({
       const url = `${
         process.env.NEXT_PUBLIC_CATALOG_URL
       }/api/v1/search_multiple?tcg=${get().tcg}&websites=${get()
-        .selectedWebsites.map((v) => v.code)
+        .selectedWebsites.map((v) => v.slug)
         .join(',')}&names=${encodedNames}`;
 
       const response = await axiosInstance.get(url);
@@ -145,7 +145,7 @@ const useMultiSearchStore = create<MultiSearchState>((set, get) => ({
     set((state) => {
       // Find the index of the website by its code
       const index = state.selectedWebsites.findIndex(
-        (v) => v.code === value.code
+        (v) => v.slug === value.slug
       );
 
       // If the website is found, remove it from the list

--- a/stores/store.ts
+++ b/stores/store.ts
@@ -46,14 +46,14 @@ const promoMap: PromoMap = {};
 type State = {
   websites: Website[];
   promoMap: PromoMap;
-  getWebsiteNameByCode: (code: string) => string;
+  getWebsiteNameByCode: (slug: string) => string;
 
   initWebsiteInformation: () => Promise<void>;
 };
 
 export const useStore = create<State>((set, get) => ({
-  getWebsiteNameByCode: (code: string) => {
-    return get().websites.find((w) => w.code === code)?.name || '';
+  getWebsiteNameByCode: (slug: string) => {
+    return get().websites.find((w) => w.slug === slug)?.name || '';
   },
 
   websites: websites,

--- a/types/website.ts
+++ b/types/website.ts
@@ -1,15 +1,12 @@
 export type Website = {
   name: string;
-  code: string;
+  slug: string;
   url: string;
-  shopify: boolean;
-  backend: string;
-  image: string;
-  promoCode: string;
-  discount: number;
+  backend: string[];
+  tcgs: string[];
 };
 
 export type WebsiteMapping = {
   name: string;
-  code: string;
+  slug: string;
 };


### PR DESCRIPTION
- Changed all references to website.code to website.slug to match new database schema
- Updated website types to reflect new endpoint return data
```json
{
    "websiteList": [
        {
            "slug": "houseofcards",
            "name": "House of Cards",
            "backend": [
                "BINDER_POS"
            ],
            "url": "https://houseofcards.ca/",
            "tcgs": [
                "MTG",
                "POKEMON",
                "YUGIOH",
                "LORCANA"
            ]
        },
        {
            "slug": "exorgames",
            "name": "Exor Games",
            "backend": [
                "BINDER_POS"
            ],
            "url": "https://exorgames.com/",
            "tcgs": [
                "MTG",
                "POKEMON",
                "YUGIOH",
                "LORCANA"
            ]
        },
        {
            "slug": "abyss",
            "name": "Abyss Game Store",
            "backend": [
                "BINDER_POS"
            ],
            "url": "https://www.abyssgamestore.com/",
            "tcgs": [
                "MTG",
                "POKEMON",
                "YUGIOH",
                "LORCANA"
            ]
        }
      ]
    }
 ```
     