### PR TITLE
Recommened stores fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2024-07-31
+
+### Changed
+
+- Hard coded exor games, level up games, and chimera games as options in the recommended stores options in /pages/multisearch/index.tsx
+- you can add and remove websites in the reccomendedWebsites list which contains a list of reccomended stores by slug
+- this pull from the postgres tables in the future
+
 ## 2024-07-18
 
 ### Changed

--- a/pages/multisearch/index.tsx
+++ b/pages/multisearch/index.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Loader2, Minus, Plus, Scroll, Trash2 } from 'lucide-react';
@@ -298,7 +298,8 @@ const ResultSelector = () => {
     useMultiSearchStore();
   const { getWebsiteName } = useGlobalStore();
   const totalRequested = results.length;
-
+  const reccomendedWebsites = ['obsidian', 'levelup', 'chimera', 'exorgames'];
+  const [selectedTopStore, setSelectedTopStore] = useState("")
   const getTopWebsites = (results: MultiSearchProduct[]) => {
     const websiteProductSet: { [website: string]: Set<string> } = {};
     const websiteProductPrices: {
@@ -327,7 +328,7 @@ const ResultSelector = () => {
     const websiteCount: { [website: string]: number } = {};
     const websiteTotalCost: { [website: string]: number } = {};
     Object.entries(websiteProductSet).forEach(([website, productSet]) => {
-      if (website !== 'obsidian') {
+      if (!reccomendedWebsites.includes(website)) {
         return;
       }
       websiteCount[website] = productSet.size;
@@ -371,7 +372,7 @@ const ResultSelector = () => {
         <div className="flex flex-col gap-2 overflow-clip rounded px-6">
           {getTopWebsites(results).map((websiteInfo, i) => {
             return (
-              <DialogTrigger asChild>
+              <DialogTrigger asChild onClick={()=>{{setSelectedTopStore(websiteInfo.website)}}}>
                 <div
                   className="border-1 rounded-md border border-accent px-4 py-3 text-left transition-colors hover:cursor-pointer hover:bg-accent"
                   key={i}
@@ -411,7 +412,7 @@ const ResultSelector = () => {
                     setSelectedResult(result);
                   }}
                 >
-                  <TableCell className="py-2 text-left">
+                  <TableCell className="py-2 text-left capitalize">
                     {result.name}
                   </TableCell>
                   <TableCell className="py-2 text-right">
@@ -429,8 +430,7 @@ const ResultSelector = () => {
         <DialogHeader>
           <DialogTitle>Add to cart</DialogTitle>
           <DialogDescription>
-            Clicking below will add all results from Obsidian Games to your
-            cart.
+            {`Clicking below will add all results from to your cart.`}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -439,7 +439,7 @@ const ResultSelector = () => {
               onClick={() => {
                 results.forEach((result) => {
                   const obsidianProducts = result.results.filter(
-                    (product) => product.website === 'obsidian'
+                    (product) => product.website === selectedTopStore
                   );
                   if (obsidianProducts.length > 0) {
                     const cheapestProduct = obsidianProducts.reduce(


### PR DESCRIPTION
**purpose:** hard code the new partnered stores in the recommended stores box in multi search

**Files Changed:**
- _pages/multisearch/index.tsx_

- Hard coded exor games, level up games, and chimera games as options in the recommended stores options in /pages/multisearch/index.tsx
- you can add and remove websites in the reccomendedWebsites list which contains a list of reccomended stores by slug
- this pull from the postgres tables in the future

![image](https://github.com/user-attachments/assets/4b1c9081-bc07-42a3-aa26-e1ad27cf9ad7)
