### PR TITLE
Buylist Mobile UI QOL Updates.

### DIFF
--- a/components/buylists/buylist-cart.tsx
+++ b/components/buylists/buylist-cart.tsx
@@ -47,7 +47,7 @@ export default function BuyListCart({ mobile }: Props) {
           </SheetTrigger>
           <SheetContent className="w-svw  sm:max-w-full">
             <SheetHeader>
-              <SheetTitle className="text-left text-3xl font-medium">
+              <SheetTitle className="text-left text-3xl font-semibold">
                 Cart
               </SheetTitle>
             </SheetHeader>
@@ -98,7 +98,7 @@ export default function BuyListCart({ mobile }: Props) {
         </Sheet>
       ) : (
         <div className="sticky top-5 max-h-[85svh]">
-          <h1 className="pb-2 text-2xl">Cart</h1>
+          <h1 className="pb-2 text-2xl font-semibold">Cart</h1>
           <ScrollArea
             className="flex max-h-[85svh] flex-col overflow-y-auto rounded"
             type="scroll"

--- a/components/buylists/buylist-filter-container.tsx
+++ b/components/buylists/buylist-filter-container.tsx
@@ -18,6 +18,7 @@ import { MixerHorizontalIcon } from '@radix-ui/react-icons';
 import { Button } from '../ui/button';
 import FilterDropDownMultiple from './filter-drop-down-multiple';
 import useBuyListStore from '@/stores/buyListStore';
+import { useState } from 'react';
 
 type Props = { mobile: boolean };
 
@@ -38,12 +39,12 @@ export default function BuyListFilterContainer({ mobile }: Props) {
     updateSelectedSortBy,
     fetchCards
   } = useBuyListStore();
-
+  const [sheetOpen, setSheetOpen] = useState(false);
   return (
     <>
       {mobile == true ? (
         <>
-          <Sheet>
+          <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
             <SheetTrigger asChild={true} className="w-full">
               <Button className="relative flex w-full items-center justify-center">
                 <p className="absolute left-1/2 -translate-x-1/2 transform">
@@ -54,7 +55,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
             </SheetTrigger>
             <SheetContent side={'left'} className="w-svw  sm:max-w-full">
               <SheetHeader>
-                <SheetTitle className="text-left text-3xl font-medium">
+                <SheetTitle className="text-left text-3xl font-semibold">
                   Filters
                 </SheetTitle>
               </SheetHeader>
@@ -104,8 +105,9 @@ export default function BuyListFilterContainer({ mobile }: Props) {
                 <Button
                   onClick={() => {
                     fetchCards();
+                    setSheetOpen(false);
                   }}
-                  className="text-md mt-6 h-9 rounded-sm  font-semibold "
+                  className="text-md mt-6 h-9 font-semibold "
                 >
                   Apply Filters
                 </Button>
@@ -115,7 +117,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
                   onClick={() => {
                     resetAllFilters();
                   }}
-                  className={`text-md mt-2 h-9 rounded-sm bg-red-600  font-semibold  `}
+                  className={`text-md mt-2 h-9 bg-red-600  font-semibold  `}
                 >
                   Reset Filters
                 </Button>
@@ -178,7 +180,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
                 onClick={() => {
                   fetchCards();
                 }}
-                className=" h-8 rounded-sm text-sm font-semibold sm:w-[180px]"
+                className=" h-8 text-sm font-semibold sm:w-[180px]"
               >
                 Apply Filters
               </Button>
@@ -187,7 +189,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
                 onClick={() => {
                   resetAllFilters();
                 }}
-                className={`ml-2 h-8  rounded-sm  bg-red-600 font-semibold  sm:w-[180px]`}
+                className={`ml-2 h-8 bg-red-600 font-semibold  sm:w-[180px]`}
               >
                 Reset Filters
               </Button>

--- a/components/buylists/buylist-search-box.tsx
+++ b/components/buylists/buylist-search-box.tsx
@@ -42,7 +42,7 @@ export default function BuyListSearchBox() {
     <div className="flex">
       {/* Select TCG Dropdown */}
       <Select onValueChange={changeTCG}>
-        <SelectTrigger className="border-border-colour w-1/2 rounded-r-none focus:ring-0 focus:ring-offset-0 sm:w-[180px]">
+        <SelectTrigger className="border-border-colour w-1/2 rounded-r-none font-semibold focus:ring-0 focus:ring-offset-0 sm:w-[180px]">
           <SelectValue placeholder="MTG" />
         </SelectTrigger>
         <SelectContent>

--- a/components/buylists/filter-drop-down-multiple.tsx
+++ b/components/buylists/filter-drop-down-multiple.tsx
@@ -66,7 +66,10 @@ export default function FilterDropDownMultiple({
     <DropdownMenu>
       <span className="flex-1">
         <span className="flex">
-          <p className="text-sm">{filterName}:</p> &nbsp;
+          <p className="text-sm">
+            {filterName == 'Foil' ? 'Edition' : 'Foil'}:
+          </p>{' '}
+          &nbsp;
           {selectedItems.length > 0 ? (
             <p className="text-sm">({selectedItems.length})</p>
           ) : (
@@ -79,7 +82,9 @@ export default function FilterDropDownMultiple({
           className="border-border-colour h-8 w-full bg-popover  focus:ring-0 "
         >
           <Button variant="outline" className="flex gap-2 text-left font-bold">
-            <span className="w-full font-medium"> {filterName}</span>
+            <span className="w-full font-medium">
+              {filterName == 'Foil' ? 'Edition' : 'Foil'}
+            </span>
             <CaretDownIcon></CaretDownIcon>
           </Button>
         </DropdownMenuTrigger>

--- a/components/buylists/result-card.tsx
+++ b/components/buylists/result-card.tsx
@@ -81,14 +81,7 @@ const ResultCard = memo(function ResultCard({ cardData }: Props) {
     <>
       <Card>
         <div className="border-border-colour grid grid-cols-12 rounded-md bg-popover p-4">
-          <div className="col-span-3">
-            <div className="flex h-full items-center justify-center">
-              <div className="relative mx-auto max-w-[150px] md:max-w-[250px]">
-                <CardImage imageUrl={cardData.image} alt="test image" />
-              </div>
-            </div>
-          </div>
-          <div className="col-span-9 flex flex-col pl-4">
+          <div className="col-span-9 flex flex-col pr-4">
             <div>
               <CardTitle className="text-md font-semibold">
                 {cardData.name}
@@ -100,7 +93,7 @@ const ResultCard = memo(function ResultCard({ cardData }: Props) {
             <div className="mt-auto">
               <div className="flex flex-row gap-2 text-sm font-semibold capitalize text-muted-foreground">
                 <p>
-                  {cardData.rarity} {cardData.foil}
+                  {cardData.rarity} - {cardData.foil}
                 </p>
               </div>
               <div className="flex text-sm">
@@ -236,6 +229,13 @@ const ResultCard = memo(function ResultCard({ cardData }: Props) {
                     </SelectGroup>
                   </SelectContent>
                 </Select>
+              </div>
+            </div>
+          </div>
+          <div className="col-span-3">
+            <div className="flex h-full items-center justify-center">
+              <div className="relative mx-auto max-w-[150px] md:max-w-[250px]">
+                <CardImage imageUrl={cardData.image} alt="test image" />
               </div>
             </div>
           </div>

--- a/pages/buylists/index.tsx
+++ b/pages/buylists/index.tsx
@@ -55,7 +55,7 @@ const Buylist: NextPage<Props> = () => {
         <div className="mt-8 w-full md:grid md:grid-cols-12 md:gap-x-4  ">
           {/* Results Container*/}
           <div className=" md:col-span-7">
-            <h1 className="pb-2 text-2xl">Results</h1>
+            <h1 className="pb-2 text-2xl font-semibold">Results</h1>
             {/* Results Cards Container*/}
 
             {buyListQueryResults.map((item: any, key: number) => (


### PR DESCRIPTION
**Purpose:** Adjust the buylists result card so the card image displays on the right side to make it easier for users to scroll down with their right hand and prevent clicking a drop down they didn't mean to click. Also adjusted the mobile filter sheet to automatically close when the user clicks apply filter rather than making them click the close button an additional time.

![image](https://github.com/user-attachments/assets/0a995848-8310-4762-88fb-834828affb27)
