### PR TITLE
fixed Shadcn Select component bug affecting touch screen devices

### DIFF
--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -89,7 +89,15 @@ const SelectContent = React.forwardRef<
 >(({ className, children, position = 'popper', ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
-      ref={ref}
+      //radix bug that causes elemensts from the selectable drop down option also click the element behind it on mobile devices specifically
+      //I replaced the ref to prevent this from happening on screen touch - Henry
+      //ref={ref}
+      ref={(ref) => {
+        if (!ref) return;
+        ref.ontouchstart = (e) => {
+          e.preventDefault();
+        };
+      }}
       className={cn(
         'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&


### PR DESCRIPTION
**Purpose:** ShadCN's provided code for the Select Component comes with a bug where clicking the selectable dropdown options on touch screen devices such as mobile also causes interactive elements such as buttons hidden behind it to also be clicked. This was causing the add to cart button to also be clicked when a user selected a store option that overlapped it to trigger both at the same time.

**Affected Files:**
- _components/ui/select.tsx_

![select_bug](https://github.com/user-attachments/assets/af80a42c-e40d-414f-a679-20a8b450ed69)

**Changes:** Updated the ref for the select primitive to stop it's default behavior on screen touch. This will fix this behavior any other place we use Shadcn's<Select> component as well. 



