### PR TITLE
fixed dropdowns from opening when mobile scrolling and persistant filters

### DIFF
--- a/components/buylists/buylist-filter-container.tsx
+++ b/components/buylists/buylist-filter-container.tsx
@@ -27,6 +27,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
     foilData,
     rarityData,
     setData,
+    selectedSortBy,
     selectedFoilFilters,
     selectedRarityFilters,
     selectedSetFilters,
@@ -40,6 +41,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
     fetchCards
   } = useBuyListStore();
   const [sheetOpen, setSheetOpen] = useState(false);
+
   return (
     <>
       {mobile == true ? (
@@ -61,6 +63,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
               </SheetHeader>
               <div className="mt-8 grid gap-y-2">
                 <Select
+                  value={selectedSortBy}
                   onValueChange={(value) => {
                     updateSelectedSortBy(value);
                   }}
@@ -148,6 +151,7 @@ export default function BuyListFilterContainer({ mobile }: Props) {
             />
             <span className="mt-auto flex-1">
               <Select
+                value={selectedSortBy}
                 onValueChange={(value) => {
                   updateSelectedSortBy(value);
                 }}

--- a/components/buylists/filter-drop-down-multiple.tsx
+++ b/components/buylists/filter-drop-down-multiple.tsx
@@ -7,10 +7,10 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { Button } from '../ui/button';
-import { useEffect, useState } from 'react';
 import { CaretDownIcon } from '@radix-ui/react-icons';
 import useBuyListStore from '@/stores/buyListStore';
 import { ScrollArea } from '@/components/ui/scroll-area';
+
 interface Props {
   values: {
     key: string;
@@ -27,48 +27,24 @@ export default function FilterDropDownMultiple({
   setFilterFunction,
   selectedZustandFilters
 }: Props) {
-  const { checkAtleastOneFilter, atLeastOneFilter, selectedTCG } =
-    useBuyListStore();
-  const [selectedItems, setSelectedItems] = useState<string[]>([]);
+  const { checkAtleastOneFilter, atLeastOneFilter } = useBuyListStore();
+
   const handleSelectChange = (value: string) => {
-    if (!selectedItems.includes(value)) {
-      setSelectedItems((prev) => [...prev, value]);
-    } else {
-      const referencedArray = [...selectedItems];
-      const indexOfItemToBeRemoved = referencedArray.indexOf(value);
-      referencedArray.splice(indexOfItemToBeRemoved, 1);
-      setSelectedItems(referencedArray);
-    }
+    const newSelectedItems = selectedZustandFilters.includes(value)
+      ? selectedZustandFilters.filter((item) => item !== value) // Deselect
+      : [...selectedZustandFilters, value]; // Select
+
+    setFilterFunction(newSelectedItems); // Update Zustand store
+    checkAtleastOneFilter(); // Check if at least one filter is selected
   };
-
-  const isOptionSelected = (value: string): boolean => {
-    return selectedItems.includes(value) ? true : false;
-  };
-
-  useEffect(() => {
-    setFilterFunction([]);
-    setSelectedItems([]);
-    checkAtleastOneFilter();
-  }, [selectedTCG]);
-
-  useEffect(() => {
-    setFilterFunction(selectedItems);
-    checkAtleastOneFilter();
-  }, [selectedItems]);
-
-  useEffect(() => {
-    if (atLeastOneFilter == false) {
-      setSelectedItems([]);
-    }
-  }, [atLeastOneFilter]);
 
   return (
     <DropdownMenu>
       <span className="flex-1">
         <span className="flex">
           <p className="text-sm">{filterName}:</p> &nbsp;
-          {selectedItems.length > 0 ? (
-            <p className="text-sm">({selectedItems.length})</p>
+          {selectedZustandFilters.length > 0 ? (
+            <p className="text-sm">({selectedZustandFilters.length})</p>
           ) : (
             <p className="text-sm">Any</p>
           )}
@@ -80,7 +56,7 @@ export default function FilterDropDownMultiple({
         >
           <Button variant="outline" className="flex gap-2 text-left font-bold">
             <span className="w-full font-medium"> {filterName}</span>
-            <CaretDownIcon></CaretDownIcon>
+            <CaretDownIcon />
           </Button>
         </DropdownMenuTrigger>
       </span>
@@ -92,23 +68,21 @@ export default function FilterDropDownMultiple({
         <DropdownMenuLabel>Select {filterName}:</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <ScrollArea
-          className="flex max-h-80 flex-col overflow-y-auto  "
+          className="flex max-h-80 flex-col overflow-y-auto"
           type="always"
         >
           {Array.isArray(values) &&
-            values.map((value: Props['values'][0], index: number) => {
-              return (
-                <DropdownMenuCheckboxItem
-                  onSelect={(e) => e.preventDefault()}
-                  key={index}
-                  checked={isOptionSelected(value.key)}
-                  onCheckedChange={() => handleSelectChange(value.key)}
-                  className="capitalize"
-                >
-                  {value.value}
-                </DropdownMenuCheckboxItem>
-              );
-            })}
+            values.map((value, index) => (
+              <DropdownMenuCheckboxItem
+              onSelect={(e) => e.preventDefault()}
+              key={index}
+                checked={selectedZustandFilters.includes(value.key)}
+                onCheckedChange={() => handleSelectChange(value.key)}
+                className="capitalize"
+              >
+                {value.value}
+              </DropdownMenuCheckboxItem>
+            ))}
         </ScrollArea>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -5,10 +5,58 @@ import { Inter } from 'next/font/google';
 const inter = Inter({ subsets: ['latin'] });
 import { cn } from '@/lib/utils';
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuContext = React.createContext<
+  React.Dispatch<React.SetStateAction<boolean>>
+>(() => {});
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
-
+// const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenu: React.FC<DropdownMenuPrimitive.DropdownMenuProps> = (
+  props
+) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <DropdownMenuContext.Provider value={setIsOpen}>
+      <DropdownMenuPrimitive.Root
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        {...props}
+      />
+    </DropdownMenuContext.Provider>
+  );
+};
+// const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => {
+  const setIsOpen = React.useContext(DropdownMenuContext);
+  return (
+    <DropdownMenuPrimitive.Trigger
+      ref={(ref) => {
+        if (!ref) return;
+        ref.ontouchstart = (e) => {
+          e.preventDefault();
+        };
+      }}
+      className={cn(
+        'flex h-10 w-full items-center justify-between rounded-lg border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+        className
+      )}
+      {...props}
+      onPointerDown={(e) => {
+        if (e.pointerType === 'touch') e.preventDefault(); // disable the default behavior in mobile
+      }}
+      onPointerUp={(e) => {
+        if (e.pointerType === 'touch') {
+          setIsOpen((prevState) => !prevState); // use onPointerUp to simulate onClick in mobile
+        }
+      }}
+    >
+      {children}
+    </DropdownMenuPrimitive.Trigger>
+  );
+});
+DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;

--- a/stores/buyListStore.ts
+++ b/stores/buyListStore.ts
@@ -30,15 +30,15 @@ type BuyListState = {
   individualStoreCart: any[];
   buyListCartData: any[];
   showFilters: boolean;
-  
+
   addToCart: (store: string, cardData: any) => void;
   removeFromCart: (store: string, cardData: any) => void;
   clearAllCartItems: () => void;
   selectedFoilFilters: any[];
   selectedRarityFilters: any[];
   selectedSetFilters: any[];
-  selectedSortBy:string;
-  updateSelectedSortBy: (sortByOption:string) => void;
+  selectedSortBy: string;
+  updateSelectedSortBy: (sortByOption: string) => void;
   updateSelectedFoilFilters: (filters: string[]) => void;
   updateSelectedRarityFilters: (filters: string[]) => void;
   updateSelectedSetFilters: (filters: string[]) => void;
@@ -52,7 +52,6 @@ type BuyListState = {
   fetchCards: () => void;
   filtersVisibile: boolean;
 };
-
 
 const useBuyListStore = create<BuyListState>((set, get) => ({
   foilData: {},
@@ -71,9 +70,9 @@ const useBuyListStore = create<BuyListState>((set, get) => ({
   searchTerm: '',
   filtersVisibile: false,
   showFilters: false,
-  selectedSortBy:'best-match',
-  updateSelectedSortBy(sortByOption: string){
-    set({selectedSortBy:sortByOption})
+  selectedSortBy: 'best-match',
+  updateSelectedSortBy(sortByOption: string) {
+    set({ selectedSortBy: sortByOption });
   },
 
   updateSelectedFoilFilters(filters: string[]) {
@@ -228,60 +227,67 @@ const useBuyListStore = create<BuyListState>((set, get) => ({
   },
 
   fetchCards: async () => {
-    if (get().searchTerm){
-    const queryParams = new URLSearchParams({
-      name: get().searchTerm,
-      tcg: get().selectedTCG,
-      sortBy: get().selectedSortBy,
-      sets:  get().selectedSetFilters.map(set => encodeURIComponent(set)).join(','), // Comma-separated values
-      foils: get().selectedFoilFilters.map(foil => encodeURIComponent(foil)).join(','), // Comma-separated values
-      rarities: get().selectedRarityFilters.map(rarity => encodeURIComponent(rarity)).join(',') // Comma-separated values
-    });
-    const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/search?${queryParams.toString()}`
-    );
+    if (get().searchTerm) {
+      const queryParams = new URLSearchParams({
+        name: get().searchTerm,
+        tcg: get().selectedTCG,
+        sortBy: get().selectedSortBy,
+        sets: get()
+          .selectedSetFilters.map((set) => encodeURIComponent(set))
+          .join(','), // Comma-separated values
+        foils: get()
+          .selectedFoilFilters.map((foil) => encodeURIComponent(foil))
+          .join(','), // Comma-separated values
+        rarities: get()
+          .selectedRarityFilters.map((rarity) => encodeURIComponent(rarity))
+          .join(',') // Comma-separated values
+      });
+      const response = await axios.get(
+        `${
+          process.env.NEXT_PUBLIC_BUYLISTS_URL
+        }/search?${queryParams.toString()}`
+      );
 
-    if (response.status !== 200) {
-      throw new Error(`Error: ${response.status} - ${response.statusText}`);
+      if (response.status !== 200) {
+        throw new Error(`Error: ${response.status} - ${response.statusText}`);
+      }
+
+      set({ buyListQueryResults: response.data.results.slice(0, 500) });
+      set({ filtersVisibile: true });
+
+      const setData = {
+        Sets: response.data.sets
+          .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
+          .map((item: string) => ({
+            key: item,
+            value: item
+          }))
+      };
+      const rarityData = {
+        Rarity: response.data.rarities
+          .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
+          .map((item: string) => ({
+            key: item,
+            value: item
+          }))
+      };
+      const foilData = {
+        Foil: response.data.foils
+          .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
+          .map((item: string) => ({
+            key: item,
+            value: item
+          }))
+      };
+      set({
+        setData: setData,
+        rarityData: rarityData,
+        foilData: foilData
+      });
+      set({ showFilters: true });
     }
-
-    set({ buyListQueryResults: response.data.results.slice(0, 500) });
-    set({ filtersVisibile: true });
-
-    const setData = {
-      Sets: response.data.sets
-        .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
-        .map((item: string) => ({
-          key: item,
-          value: item
-        }))
-    };
-    const rarityData = {
-      Rarity: response.data.rarities
-      .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
-      .map((item: string) => ({
-        key: item,
-        value: item
-      }))
-    };
-    const foilData = {
-      Foil: response.data.foils
-      .sort((a: string, b: string) => a.localeCompare(b)) // Sort the sets alphabetically
-      .map((item: string) => ({
-        key: item,
-        value: item
-      }))
-    };
-    set({
-      setData: setData,
-      rarityData: rarityData,
-      foilData: foilData
-    });
-    set({ showFilters: true });
-    }
-
   },
-  
+
   setSearchTerm(searchBoxValue: string) {
     set({ searchTerm: searchBoxValue });
   }


### PR DESCRIPTION
**Purpose:** Fixed Shadcn's premade components for DropDownMenu and Select from auto opening when scrolling over on mobile. Fixed the filters on buylists from not being persistent when switching from mobile to desktop view.

**Relevant files Affected:**
- components/buylists/buylist-filter-container.tsx
- components/buylists/filter-drop-down-multiple.tsx
- components/ui/dropdown-menu.tsx
- components/ui/select.tsx

![image](https://github.com/user-attachments/assets/d6830844-f577-4389-9a9e-bbfb7c39c66b)
