### PR TITLE
Adjusted Single Search Loading Logic

### DIFF
--- a/components/single-search/single-catalog-container.tsx
+++ b/components/single-search/single-catalog-container.tsx
@@ -1,17 +1,24 @@
-import { useSingleSearchStore } from "@/stores/useSingleSearchStore";
-import BackToTopButton from "../ui/back-to-top-btn";
-import SingleSortBy from "./single-sort-by";
-import SingleCatalogItem from "./single-catalog-item";
-import FilterSection from "./single-filter-container";
-import SinglePagination from "./single-pagination";
-import useAuthStore from "@/stores/authStore";
-import useGlobalStore from "@/stores/globalStore";
-import AdComponent from "../ad";
-import type { Ad } from "@/types/ads";
-import React, { useState, useEffect, useMemo } from "react";
+import { useSingleSearchStore } from '@/stores/useSingleSearchStore';
+import BackToTopButton from '../ui/back-to-top-btn';
+import SingleSortBy from './single-sort-by';
+import SingleCatalogItem from './single-catalog-item';
+import FilterSection from './single-filter-container';
+import SinglePagination from './single-pagination';
+import useAuthStore from '@/stores/authStore';
+import useGlobalStore from '@/stores/globalStore';
+import AdComponent from '../ad';
+import type { Ad } from '@/types/ads';
+import React, { useState, useEffect, useMemo } from 'react';
 
 export default function SingleCatalog() {
-  const { searchResults, promotedResults, numResults } = useSingleSearchStore();
+  const {
+    searchResults,
+    promotedResults,
+    numResults,
+    loadingCardResults,
+    loadingFilterResults,
+    filters
+  } = useSingleSearchStore();
   const { hasActiveSubscription } = useAuthStore();
   const { getRandomAd } = useGlobalStore();
 
@@ -19,7 +26,7 @@ export default function SingleCatalog() {
 
   const adBeforePromoted = useMemo(() => {
     if (!hasActiveSubscription) {
-      return getRandomAd('5'); 
+      return getRandomAd('5');
     }
     return null;
   }, [hasActiveSubscription, getRandomAd]);
@@ -31,62 +38,98 @@ export default function SingleCatalog() {
       for (let i = 0; i < adCount; i++) {
         adList.push(getRandomAd('5'));
       }
-      setAds(adList); 
+      setAds(adList);
     }
-  }, [searchResults, hasActiveSubscription, getRandomAd]); 
+  }, [searchResults, hasActiveSubscription, getRandomAd]);
 
   return (
     <div className="grid min-h-svh gap-6 md:grid-cols-[240px_1fr]">
       <div className="flex flex-col gap-6">
-        <div className="grid gap-4">
-          <div className="relative flex flex-col w-full gap-2">
-          <div className="child-2 md:hidden">
+        <div className="grid h-full gap-4">
+          {/* Skeleton for Filters */}
+          {loadingFilterResults && (
+            <div className="h-full w-full animate-pulse rounded-lg bg-accent"></div>
+          )}
+          {!loadingFilterResults && filters && (
+            <div className="relative flex w-full flex-col gap-2">
+              <div className="child-2 md:hidden">
+                <SingleSortBy />
+              </div>
+              <div className="child-1 w-full">
+                <FilterSection />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      {loadingCardResults && (
+        <div className="grid h-min gap-6">
+          <div className="h-10 w-full animate-pulse rounded-lg bg-accent"></div>{' '}
+          <div className="grid h-min gap-6">
+            <div className="flex justify-between">
+              {/* Skeleton for Heading */}
+              <div className="h-8 w-40 animate-pulse rounded-lg bg-accent"></div>
+              <div className="hidden md:block">
+                {/* Skeleton for SingleSortBy */}
+                <div className="h-10 w-40 animate-pulse rounded-lg bg-accent"></div>
+              </div>
+            </div>
+
+            {/* Skeleton for Results Grid */}
+            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+              {[...Array(8)].map((_, index) => (
+                <div
+                  key={index}
+                  className="h-96 w-full animate-pulse rounded-lg bg-accent"
+                ></div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+      {!loadingCardResults && searchResults && (
+        <div className="grid h-min gap-6">
+          <div className="flex justify-between">
+            <div className="flex flex-col text-left">
+              <h1 className="text-2xl font-bold">Search Results</h1>
+              <p className="text-sm text-gray-500">
+                {numResults} results found
+              </p>
+            </div>
+            <div className="hidden md:block">
               <SingleSortBy />
             </div>
-            <div className="child-1 w-full">
-              <FilterSection />
+          </div>
+
+          {searchResults && (
+            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+              {adBeforePromoted && !hasActiveSubscription && (
+                <AdComponent ad={adBeforePromoted} />
+              )}
+              {promotedResults &&
+                !hasActiveSubscription &&
+                promotedResults.map((item, index) => {
+                  return <SingleCatalogItem product={item} key={index} />;
+                })}
+
+              {searchResults.map((item, index) => (
+                <React.Fragment key={index}>
+                  <SingleCatalogItem product={item} />
+
+                  {!hasActiveSubscription &&
+                    (index + 1) % 6 === 0 &&
+                    ads[Math.floor(index / 6)] && (
+                      <AdComponent ad={ads[Math.floor(index / 6)]} />
+                    )}
+                </React.Fragment>
+              ))}
             </div>
+          )}
 
-          </div>
+          {searchResults && <SinglePagination />}
         </div>
-      </div>
-      <div className="grid h-min gap-6">
-        <div className="flex justify-between">
-          <div className="text-left flex flex-col">
-          <h1 className="text-2xl font-bold">Search Results</h1>
-          <p className="text-sm text-gray-500">
-            {numResults} results found
-          </p>
-          </div>
-          <div className="hidden md:block">
-            <SingleSortBy />
-          </div>
-        </div>
+      )}
 
-        {searchResults && (
-          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-            {adBeforePromoted && !hasActiveSubscription && (
-              <AdComponent ad={adBeforePromoted} />
-            )}
-            {promotedResults && !hasActiveSubscription &&
-              promotedResults.map((item, index) => {
-                return <SingleCatalogItem product={item} key={index} />;
-              })}
-
-            {searchResults.map((item, index) => (
-              <React.Fragment key={index}>
-                <SingleCatalogItem product={item} />
-
-                {(!hasActiveSubscription && (index + 1) % 6 === 0 && ads[Math.floor(index / 6)]) && (
-                  <AdComponent ad={ads[Math.floor(index / 6)]} />
-                )}
-              </React.Fragment>
-            ))}
-          </div>
-        )}
-
-        {searchResults && <SinglePagination />}
-      </div>
       <BackToTopButton />
     </div>
   );

--- a/components/single-search/single-filter-container.tsx
+++ b/components/single-search/single-filter-container.tsx
@@ -22,7 +22,7 @@ export default function FilterSection(): JSX.Element {
   };
 
   return (
-    <div className="mx-auto w-full md:max-w-sm rounded-lg bg-popover text-left shadow-md p-4">
+    <div className="mx-auto w-full rounded-lg bg-popover p-4 text-left shadow-md md:max-w-sm">
       <h2 className="mb-6 text-2xl font-bold">Filters</h2>
 
       {filterOptions &&
@@ -40,17 +40,24 @@ export default function FilterSection(): JSX.Element {
           }
         })}
 
-        {!hasActiveSubscription && (
-          <div className="p-4 text-sm text-left border border-1 mb-4 flex flex-col gap-2">
-            <p>
-              Snapcaster <span className="text-primary font-bold">Pro</span> members get advanced filtering options.
-              
-            </p>
+      {!hasActiveSubscription && (
+        <div className="border-1 mb-4 flex flex-col gap-2 border p-4 text-left text-sm">
+          <p>
+            Snapcaster <span className="font-bold text-primary">Pro</span>{' '}
+            members get advanced filtering options.
+          </p>
 
-            <Button onClick={
-              isAuthenticated ? createCheckoutSession : () => window.location.href = '/signin'}>Subscribe</Button>
-          </div>
-        )}
+          <Button
+            onClick={
+              isAuthenticated
+                ? createCheckoutSession
+                : () => (window.location.href = '/signin')
+            }
+          >
+            Subscribe
+          </Button>
+        </div>
+      )}
 
       <Button onClick={handleClearFilters} className="w-full">
         Clear Filters
@@ -86,7 +93,7 @@ interface FilterFactoryProps {
 }
 
 const FilterFactory: React.FC<FilterFactoryProps> = ({ filterOption }) => {
-  const { fetchCards, setFilter, filters, setCurrentPage } =
+  const { fetchCards, setFilter, filters, setCurrentPage, applyFilters } =
     useSingleSearchStore();
   const handleOptionChange = (
     filter: FilterOption,
@@ -94,7 +101,7 @@ const FilterFactory: React.FC<FilterFactoryProps> = ({ filterOption }) => {
   ) => {
     setFilter(filter.field, option.value, !option.selected);
     setCurrentPage(1);
-    fetchCards();
+    applyFilters();
   };
   const { getWebsiteName } = useGlobalStore();
   return (
@@ -109,7 +116,7 @@ const FilterFactory: React.FC<FilterFactoryProps> = ({ filterOption }) => {
               onChange={(e) => handleOptionChange(filterOption, option)}
               className="mr-2 mt-1"
             />
-            <label htmlFor={option.value} className="leading-5 text-sm">
+            <label htmlFor={option.value} className="text-sm leading-5">
               {filterOption.field === 'vendor'
                 ? getWebsiteName(option.value)
                 : option.label}{' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,6 @@ type Props = {};
 const Home: NextPage<Props> = ({}: Props) => {
   const { searchResults, loading } = useSingleSearchStore();
 
-
   return (
     <>
       <HomeHead />
@@ -26,11 +25,7 @@ const Home: NextPage<Props> = ({}: Props) => {
         <div className="mx-auto flex w-full justify-center">
           <SingleSearchBar />
         </div>
-        {loading && <ResultsSkeleton />}
-
-        {!loading && searchResults && (
-          <SingleCatalog />
-        )}
+        <SingleCatalog />
       </div>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,8 +13,6 @@ import ResultsSkeleton from '@/components/single-search/results-skeleton';
 type Props = {};
 
 const Home: NextPage<Props> = ({}: Props) => {
-  const { searchResults, loading } = useSingleSearchStore();
-
   return (
     <>
       <HomeHead />


### PR DESCRIPTION
**Purpose:** Seperated the single search loading logic for the filter section and the card result section. Applying a filter would set loading to false in index.tsx which would rerender the filter section. As a result, a user could scroll through a large set list to apply a filter which would rerender the entire filter box and bring the scrollable section back to the top even though the user likely wants to continue scrolling down to apply more filters.

**Relevant Files Affected:**
- stores/useSingleSearchStore.ts
-  pages/index.tsx
- components/single-search/single-catalog-container.tsx
- components/single-search/single-filter-container.tsx

**Separated loading into loadingCardResults and  loadingFilterResults**
**Description:** removed use of the skeleton and loading logic in index.tsx and put it directly in components/single-search/single-catalog-container.tsx. fetchCards() toggles loadingCardResults and loadingFilterResults which is used for skeleton logic on new searches whereas applyfilters toggles loadingCardResults to prevent the entire filter container causing the users scroll position to reset.
**Affected Files:**
- stores/useSingleSearchStore.ts
-  pages/index.tsx
- components/single-search/single-catalog-container.tsx
- components/single-search/single-filter-container.tsx

**Additional Notes:** The changes in components/single-search/single-catalog-container.tsx included formatting changes from our prettier auto format settings.