### PR TITLE
fixed a giveawway banner width styling issue

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,11 +21,11 @@ const Home: NextPage<Props> = ({}: Props) => {
         <PoweredBy size="small" />
 
         <a
-          className="mx-auto w-min font-bold   hover:text-primary md:text-base"
+          className="mx-auto  font-bold   hover:text-primary md:text-base"
           href="https://discord.gg/EnKKHxSq75"
           target="_none"
         >
-          <p className="w-min whitespace-nowrap text-center text-sm">
+          <p className="  text-center text-sm">
             ✨Join the Snapcaster Discord to enter the Obsidian Games Pokemon
             sealed raffle in #public-giveaways on November 22 ✨
           </p>


### PR DESCRIPTION
I accidently set the width for the giveaway banner to w-min and whitespace-nowrap causing mobile styling issues. I removed those options in the banner class names and it now displays properly on desktop and mobile