### PR TITLE
fixed long coupon codes overflowing in container

### DIFF
--- a/components/sealed/sealed-catalog-item.tsx
+++ b/components/sealed/sealed-catalog-item.tsx
@@ -20,8 +20,9 @@ const DiscountBadge = ({ product }: Props) => {
         <span className="skew-x-12 transform">
           -{' '}
           {Math.floor(
-            SEALED_DISCOUNT_MAP[product.discount_code as keyof typeof SEALED_DISCOUNT_MAP] *
-              100
+            SEALED_DISCOUNT_MAP[
+              product.discount_code as keyof typeof SEALED_DISCOUNT_MAP
+            ] * 100
           )}
           %
         </span>
@@ -35,7 +36,7 @@ const SealedCatalogItem = ({ product }: Props) => {
   const { websites } = useGlobalStore();
   const { theme } = useTheme();
   const { productCategory } = useSealedSearchStore();
-  
+
   const findWebsiteNameByCode = (slug: string) => {
     const website = websites.find((website) => website.slug === slug);
     return website ? website.name : 'Website not found';
@@ -58,8 +59,8 @@ const SealedCatalogItem = ({ product }: Props) => {
       <div
         className={`group flex h-full flex-col rounded-t-lg border border-accent bg-popover p-4`}
       >
-        <div 
-          className="relative bg-white cursor-pointer hover:opacity-90 transition-opacity"
+        <div
+          className="relative cursor-pointer bg-white transition-opacity hover:opacity-90"
           onClick={handleClick}
         >
           {product.promoted && (
@@ -74,17 +75,19 @@ const SealedCatalogItem = ({ product }: Props) => {
 
         <div>
           <div className="mt-3 flex flex-grow flex-col text-center md:text-left">
-            <h3 
+            <h3
               onClick={handleClick}
-              className="overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight cursor-pointer"
-            >{product.name}</h3>
-            <div 
-              className="mb-2 mt-1 flex flex-col md:flex-row items-center justify-center w-full md:justify-start gap-1 cursor-pointer hover:opacity-80 transition-opacity"
+              className="cursor-pointer overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight"
+            >
+              {product.name}
+            </h3>
+            <div
+              className="mb-2 mt-1 flex w-full cursor-pointer flex-col items-center justify-center gap-1 transition-opacity hover:opacity-80 md:flex-row md:justify-start"
               onClick={handleClick}
             >
-            <div className="md:hidden text-xs">
-              {findWebsiteNameByCode(product.vendor)}
-            </div>
+              <div className="text-xs md:hidden">
+                {findWebsiteNameByCode(product.vendor)}
+              </div>
               {(() => {
                 const matchingWebsite = websites.find(
                   (website) => product.vendor === website.slug
@@ -101,66 +104,75 @@ const SealedCatalogItem = ({ product }: Props) => {
                   />
                 ) : null;
               })()}
-                   <div className="hidden md:block text-xs ml-1">
-              {findWebsiteNameByCode(product.vendor)}
-            </div>
-
+              <div className="ml-1 hidden text-xs md:block">
+                {findWebsiteNameByCode(product.vendor)}
+              </div>
             </div>
             <div className="mt-3">
-              <div 
-                className="flex flex-row items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity justify-center md:justify-start"
+              <div
+                className="flex cursor-pointer flex-row items-center justify-center gap-2 transition-opacity hover:opacity-80 md:justify-start"
                 onClick={handleClick}
               >
-                <h4 className="font-montserrat text-2xl font-semibold flex items-start">
-                  <span className="text-sm mt-1">$</span>{(() => {
+                <h4 className="flex items-start font-montserrat text-2xl font-semibold">
+                  <span className="mt-1 text-sm">$</span>
+                  {(() => {
                     const price = Number(
-                      product.discounted_price && SEALED_DISCOUNT_MAP[product.discount_code as keyof typeof SEALED_DISCOUNT_MAP] 
-                        ? product.discounted_price 
+                      product.discounted_price &&
+                        SEALED_DISCOUNT_MAP[
+                          product.discount_code as keyof typeof SEALED_DISCOUNT_MAP
+                        ]
+                        ? product.discounted_price
                         : product.price
                     ).toFixed(2);
                     const [dollars, cents] = price.split('.');
                     return (
                       <div className="flex items-start">
                         <span className="text-3xl">{dollars}</span>
-                        <span className="text-sm mt-1">{cents}</span>
+                        <span className="mt-1 text-sm">{cents}</span>
                       </div>
                     );
                   })()}
                 </h4>
-                {product.discount_code && SEALED_DISCOUNT_MAP[product.discount_code as keyof typeof SEALED_DISCOUNT_MAP] && (
-                  <DiscountBadge product={product} />
-                )}
+                {product.discount_code &&
+                  SEALED_DISCOUNT_MAP[
+                    product.discount_code as keyof typeof SEALED_DISCOUNT_MAP
+                  ] && <DiscountBadge product={product} />}
               </div>
-              {product.discount_code && SEALED_DISCOUNT_MAP[product.discount_code as keyof typeof SEALED_DISCOUNT_MAP] && (
-                <div
-                  className="-mt-0.5 flex w-full text-[0.8rem]"
-                  key={product.vendor}
-                >
-                  <div className="text-center md:text-left font-montserrat tracking-tighter text-muted-foreground w-full">
-                    With code:<br/>
-                    <span className="font-bold break-all">{product.discount_code}</span>
+              {product.discount_code &&
+                SEALED_DISCOUNT_MAP[
+                  product.discount_code as keyof typeof SEALED_DISCOUNT_MAP
+                ] && (
+                  <div
+                    className="-mt-0.5 flex w-full text-[0.8rem]"
+                    key={product.vendor}
+                  >
+                    <div className="w-full text-center font-montserrat tracking-tighter text-muted-foreground md:text-left">
+                      With code:
+                      <br />
+                      <span className="break-all font-bold">
+                        {product.discount_code}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
             </div>
           </div>
         </div>
         <Link
-        href={product.link}
-        target="_blank"
-        rel="noreferrer"
-        className="sm:hidden w-full mt-4"
-      >
-        <Button
-          className="w-full font-montserrat text-xs uppercase"
-          variant="default"
-          onClick={handleClick}
+          href={product.link}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-4 w-full sm:hidden"
         >
-          Buy
-        </Button>
-      </Link>
+          <Button
+            className="w-full font-montserrat text-xs uppercase"
+            variant="default"
+            onClick={handleClick}
+          >
+            Buy
+          </Button>
+        </Link>
       </div>
-  
     </div>
   );
 };

--- a/components/single-search/single-catalog-item.tsx
+++ b/components/single-search/single-catalog-item.tsx
@@ -54,78 +54,80 @@ const SingleCatalogItem = ({ product }: Props) => {
           )}
         </div>
 
-          <div>
-        <div className="mt-3">
-          <div className="flex flex-row items-center gap-2">
-            <h4 className="font-montserrat text-2xl font-semibold">
-              ${Number(product.discounted_price || product.price).toFixed(2)}
-            </h4>
-            <DiscountBadge product={product} />
+        <div>
+          <div className="mt-3">
+            <div className="flex flex-row items-center gap-2">
+              <h4 className="font-montserrat text-2xl font-semibold">
+                ${Number(product.discounted_price || product.price).toFixed(2)}
+              </h4>
+              <DiscountBadge product={product} />
+            </div>
+            {product.discount_code && (
+              <div
+                className="-mt-0.5 flex w-full text-[0.65rem]"
+                key={product.vendor}
+              >
+                <div className="text-left font-montserrat tracking-tighter text-muted-foreground">
+                  With code:{' '}
+                  <span className="break-all font-bold">
+                    {product.discount_code}
+                  </span>
+                </div>
+              </div>
+            )}
           </div>
-          {product.discount_code && (
-            <div
-              className="-mt-0.5 flex w-full text-[0.65rem]"
-              key={product.vendor}
-            >
-              <div className="text-left font-montserrat tracking-tighter text-muted-foreground">
-                With code:{' '}
-                <span className="font-bold">{product.discount_code}</span>
+          <div className="mt-3 flex flex-grow flex-col text-left">
+            <div className="text-primary-light font-montserrat text-[0.65rem]  font-semibold uppercase">
+              {product.set}
+            </div>
+
+            <h3 className="overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight">{`${
+              product.name
+            } ${
+              product.collector_number ? `(${product.collector_number})` : ''
+            }`}</h3>
+
+            <h4 className="text-[0.65rem]   uppercase tracking-tighter text-muted-foreground">{` ${
+              product.frame ? product.frame : ''
+            }  ${
+              product.finish !== 'foil' && product.finish != null
+                ? product.finish
+                : ''
+            } ${product.showcase ? product.showcase : ''} ${
+              product.alternate_art ? product.alternate_art : ''
+            } ${product.promo ? product.promo : ''} ${
+              product.art_series ? product.art_series : ''
+            }`}</h4>
+            <div className=" mb-2 mt-3 flex flex-row gap-1">
+              {(() => {
+                const matchingWebsite = websites.find(
+                  (website) => product.vendor === website.slug
+                );
+                return matchingWebsite?.meta?.branding?.icons ? (
+                  <img
+                    src={
+                      theme === 'dark'
+                        ? matchingWebsite.meta.branding.icons.dark
+                        : matchingWebsite.meta.branding.icons.light
+                    }
+                    alt="Website"
+                    className="h-4 w-4"
+                  />
+                ) : null;
+              })()}
+
+              <div className="text-xs">
+                {findWebsiteNameByCode(product.vendor)}
               </div>
             </div>
-          )}
-        </div>
-        <div className="mt-3 flex flex-grow flex-col text-left">
-          <div className="font-montserrat text-[0.65rem] font-semibold  uppercase text-primary-light">
-            {product.set}
+            <Badge
+              className={` mt-2 w-min border-2 border-muted-foreground text-white ${
+                product.finish ? 'bg-foil bg-cover bg-center' : 'bg-slate-700'
+              }`}
+            >
+              {product.condition}
+            </Badge>
           </div>
-
-          <h3 className="overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight">{`${
-            product.name
-          } ${
-            product.collector_number ? `(${product.collector_number})` : ''
-          }`}</h3>
-
-          <h4 className="text-[0.65rem]   uppercase tracking-tighter text-muted-foreground">{` ${
-            product.frame ? product.frame : ''
-          }  ${
-            product.finish !== 'foil' && product.finish != null
-              ? product.finish
-              : ''
-          } ${product.showcase ? product.showcase : ''} ${
-            product.alternate_art ? product.alternate_art : ''
-          } ${product.promo ? product.promo : ''} ${
-            product.art_series ? product.art_series : ''
-          }`}</h4>
-          <div className=" mb-2 mt-3 flex flex-row gap-1">
-            {(() => {
-              const matchingWebsite = websites.find(
-                (website) => product.vendor === website.slug
-              );
-              return matchingWebsite?.meta?.branding?.icons ? (
-                <img
-                  src={
-                    theme === 'dark'
-                      ? matchingWebsite.meta.branding.icons.dark
-                      : matchingWebsite.meta.branding.icons.light
-                  }
-                  alt="Website"
-                  className="h-4 w-4"
-                />
-              ) : null;
-            })()}
-
-            <div className="text-xs">
-              {findWebsiteNameByCode(product.vendor)}
-            </div>
-          </div>
-          <Badge
-            className={` mt-2 w-min border-2 border-muted-foreground text-white ${
-              product.finish ? 'bg-foil bg-cover bg-center' : 'bg-slate-700'
-            }`}
-          >
-            {product.condition}
-          </Badge>
-        </div>
         </div>
       </div>
       <Link

--- a/components/vendors/single-catalog-item.tsx
+++ b/components/vendors/single-catalog-item.tsx
@@ -14,18 +14,11 @@ type Props = {
   storeLogo: boolean;
 };
 
-const DiscountBadge = ({ product }: {product: SingleCatalogCard}) => {
+const DiscountBadge = ({ product }: { product: SingleCatalogCard }) => {
   if (product.discounted_price) {
     return (
       <div className="flex h-[18px] -skew-x-12 transform items-center rounded bg-primary/80 px-2 font-montserrat text-xs font-semibold leading-none text-white shadow-md">
-        <span className="skew-x-12 transform">
-          -{' '}
-          {Math.floor(
-            0.1 *
-              100
-          )}
-          %
-        </span>
+        <span className="skew-x-12 transform">- {Math.floor(0.1 * 100)}%</span>
       </div>
     );
   }
@@ -43,95 +36,89 @@ const SingleCatalogItem = ({ product, storeLogo = true }: Props) => {
 
   return (
     <div className="flex flex-col bg-popover font-montserrat">
-      <div
-        className={`group flex h-full flex-col rounded-t-lg bg-popover p-4`}
-      >
+      <div className={`group flex h-full flex-col rounded-t-lg bg-popover p-4`}>
         <div className="relative mx-auto h-min max-w-[150px] md:max-w-[250px]">
           <CardImage imageUrl={product.image} alt={product.name} />
         </div>
 
-          <div>
-        <div className="mt-3">
-          <div className="flex flex-row items-center gap-2">
-            <h4 className="font-montserrat text-2xl font-semibold">
-              ${Number(product.discounted_price || product.price).toFixed(2)}
-            </h4>
-            <DiscountBadge product={product} />
-          </div>
-          {product.discount_code && (
-            <div
-              className="-mt-0.5 flex w-full text-[0.65rem]"
-              key={product.vendor}
-            >
-              <div className="text-left font-montserrat tracking-tighter text-muted-foreground">
-                With code:{' '}
-                <span className="font-bold">{product.discount_code}</span>
+        <div>
+          <div className="mt-3">
+            <div className="flex flex-row items-center gap-2">
+              <h4 className="font-montserrat text-2xl font-semibold">
+                ${Number(product.discounted_price || product.price).toFixed(2)}
+              </h4>
+              <DiscountBadge product={product} />
+            </div>
+            {product.discount_code && (
+              <div
+                className="-mt-0.5 flex w-full text-[0.65rem]"
+                key={product.vendor}
+              >
+                <div className="text-left font-montserrat tracking-tighter text-muted-foreground">
+                  With code:{' '}
+                  <span className="break-all font-bold">
+                    {product.discount_code}
+                  </span>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-        <div className="mt-3 flex flex-grow flex-col text-left">
-          <div className="font-montserrat text-[0.65rem] font-semibold  uppercase text-primary-light">
-            {product.set}
+            )}
           </div>
-
-          <h3 className="overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight">{`${
-            product.name
-          } ${
-            product.collector_number ? `(${product.collector_number})` : ''
-          }`}</h3>
-
-          <h4 className="text-[0.65rem]   uppercase tracking-tighter text-muted-foreground">{` ${
-            product.frame ? product.frame : ''
-          }  ${
-            product.finish !== 'foil' && product.finish != null
-              ? product.finish
-              : ''
-          } ${product.showcase ? product.showcase : ''} ${
-            product.alternate_art ? product.alternate_art : ''
-          } ${product.promo ? product.promo : ''} ${
-            product.art_series ? product.art_series : ''
-          }`}</h4>
-          <div className=" mb-2 mt-3 flex flex-row gap-1">
-
-                {storeLogo && <img
-                  src={'/logo.png'}
-                  alt="Website"
-                  className="h-4 w-4"
-                />}
-   
-
-            <div className="text-xs">
-              {product.vendor}
+          <div className="mt-3 flex flex-grow flex-col text-left">
+            <div className="text-primary-light font-montserrat text-[0.65rem]  font-semibold uppercase">
+              {product.set}
             </div>
+
+            <h3 className="overflow-hidden text-ellipsis text-[0.9rem] font-semibold capitalize tracking-tight">{`${
+              product.name
+            } ${
+              product.collector_number ? `(${product.collector_number})` : ''
+            }`}</h3>
+
+            <h4 className="text-[0.65rem]   uppercase tracking-tighter text-muted-foreground">{` ${
+              product.frame ? product.frame : ''
+            }  ${
+              product.finish !== 'foil' && product.finish != null
+                ? product.finish
+                : ''
+            } ${product.showcase ? product.showcase : ''} ${
+              product.alternate_art ? product.alternate_art : ''
+            } ${product.promo ? product.promo : ''} ${
+              product.art_series ? product.art_series : ''
+            }`}</h4>
+            <div className=" mb-2 mt-3 flex flex-row gap-1">
+              {storeLogo && (
+                <img src={'/logo.png'} alt="Website" className="h-4 w-4" />
+              )}
+
+              <div className="text-xs">{product.vendor}</div>
+            </div>
+            <Badge
+              className={` mt-2 w-min border-2 border-muted-foreground text-white ${
+                product.finish ? 'bg-foil bg-cover bg-center' : 'bg-slate-700'
+              }`}
+            >
+              {product.condition}
+            </Badge>
           </div>
-          <Badge
-            className={` mt-2 w-min border-2 border-muted-foreground text-white ${
-              product.finish ? 'bg-foil bg-cover bg-center' : 'bg-slate-700'
-            }`}
-          >
-            {product.condition}
-          </Badge>
-        </div>
         </div>
       </div>
 
-        <Button
-          className="w-full rounded-b-lg border-border bg-popover font-montserrat text-xs uppercase"
-          variant="outline"
-          onClick={() =>
-            handleBuyClick(
-              product.link,
-              product.price,
-              product.name,
-              product.set,
-              product.promoted ?? false,
-              resultsTcg
-            )
-          }
-        >
-          Buy
-        </Button>
+      <Button
+        className="w-full rounded-b-lg border-border bg-popover font-montserrat text-xs uppercase"
+        variant="outline"
+        onClick={() =>
+          handleBuyClick(
+            product.link,
+            product.price,
+            product.name,
+            product.set,
+            product.promoted ?? false,
+            resultsTcg
+          )
+        }
+      >
+        Buy
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
**Purpose:** Fixed long coupon codes from overflowing outside of the card container it's in.

**Relevant Files Changed:**
- components/sealed/sealed-catalog-item.tsx
- components/single-search/single-catalog-item.tsx
- components/vendors/single-catalog-item.tsx

**(1) Fixed long coupon codes:**
All that was added was a "break-all" to the class name of the span that holds the coupon code to allow the characters go to a new line. It was was just 3 lines of code across 3 files and all the other adjustments are just prettier auto formatting.

![image](https://github.com/user-attachments/assets/e69dcb9a-b82f-4012-a16c-6cdd34b74884)
