### PR TITLE
adjust layout to prevent side banner overlap & updated socials in footer

### DIFF
--- a/components/main-page-layout.tsx
+++ b/components/main-page-layout.tsx
@@ -43,12 +43,12 @@ const AD_DIMENSIONS = {
 // Improved skeleton components with consistent dimensions
 const TopBannerSkeleton = () => (
   <div className="w-full overflow-hidden rounded-lg">
-    <div className="relative mx-auto w-full flex justify-center">
+    <div className="relative mx-auto flex w-full justify-center">
       {/* Mobile Banner */}
-      <div className="block sm:hidden w-full">
-        <div 
+      <div className="block w-full sm:hidden">
+        <div
           className="relative w-full"
-          style={{ 
+          style={{
             aspectRatio: '382/160'
           }}
         >
@@ -56,10 +56,10 @@ const TopBannerSkeleton = () => (
         </div>
       </div>
       {/* Desktop Banner */}
-      <div className="hidden sm:block w-full">
-        <div 
+      <div className="hidden w-full sm:block">
+        <div
           className="relative mx-auto"
-          style={{ 
+          style={{
             width: '100%',
             maxWidth: AD_DIMENSIONS.topBanner.desktop.width,
             height: AD_DIMENSIONS.topBanner.desktop.height,
@@ -74,9 +74,9 @@ const TopBannerSkeleton = () => (
 );
 
 const SideBannerSkeleton = () => (
-  <div 
+  <div
     className="overflow-hidden rounded-lg"
-    style={{ 
+    style={{
       width: AD_DIMENSIONS.sideBanner.width,
       height: AD_DIMENSIONS.sideBanner.height,
       aspectRatio: AD_DIMENSIONS.sideBanner.aspectRatio
@@ -87,12 +87,12 @@ const SideBannerSkeleton = () => (
 );
 
 // Simplified ad container with better layout stability
-const AdContainer = ({ 
+const AdContainer = ({
   isLoading,
   children,
   className,
   skeleton
-}: { 
+}: {
   isLoading: boolean;
   children: React.ReactNode;
   className?: string;
@@ -109,19 +109,19 @@ const AdContainer = ({
   }, [isLoading]);
 
   return (
-    <div className={cn("relative", className)}>
-      <div 
+    <div className={cn('relative', className)}>
+      <div
         className={cn(
-          "absolute inset-0 z-10 transition-opacity duration-500",
-          (!isLoading && !isTransitioning) && "opacity-0"
+          'absolute inset-0 z-10 transition-opacity duration-500',
+          !isLoading && !isTransitioning && 'opacity-0'
         )}
       >
         {skeleton}
       </div>
-      <div 
+      <div
         className={cn(
-          "transition-opacity duration-500",
-          (isLoading || isTransitioning) ? "opacity-0" : "opacity-100"
+          'transition-opacity duration-500',
+          isLoading || isTransitioning ? 'opacity-0' : 'opacity-100'
         )}
       >
         {children}
@@ -143,7 +143,7 @@ const useAdPreloader = (ads: Ad[]) => {
     setIsLoading(true);
     let mounted = true;
 
-    const imagePromises = ads.map(ad => {
+    const imagePromises = ads.map((ad) => {
       return new Promise((resolve, reject) => {
         const img = new Image();
         img.onload = resolve;
@@ -173,7 +173,7 @@ const useAdPreloader = (ads: Ad[]) => {
 };
 
 export default function MainLayout({
-  children,
+  children
 }: React.PropsWithChildren<Props>) {
   const { ads } = useGlobalStore();
   const { showAds } = useAdContext();
@@ -286,110 +286,116 @@ export default function MainLayout({
   const shouldShowAds = showAds && !hasActiveSubscription && hydrated;
 
   return (
-    <div className="container relative w-full max-w-4xl flex-1 flex-col items-center justify-center p-4 below1550:max-w-6xl">
-      {shouldShowAds && (
-        <>
-          {/* Top Banner */}
-          {topBannerAds.length > 0 && (
-            <AdContainer
-              isLoading={isTopBannerLoading}
-              skeleton={<TopBannerSkeleton />}
-              className="mb-4 w-full"
-            >
-              <Carousel
-                className="w-full overflow-hidden rounded-lg"
-                plugins={[topAutoPlayPlugin.current]}
+    <div className="flex min-h-svh">
+      {/* Left Banner */}
+      <div className="container hidden w-full max-w-4xl flex-1 p-4 smlaptop:block">
+        <div className="sticky top-1/3 hidden smlaptop:block">
+          {leftCarouselAds.length > 0 && (
+            <div className=" ">
+              <AdContainer
+                isLoading={isLeftCarouselLoading}
+                skeleton={<SideBannerSkeleton />}
               >
-                <CarouselContent>
-                  {topBannerAds.map((ad, index) => (
-                    <CarouselItem key={index} className="flex justify-center">
-                      {/* Mobile Banner */}
-                      <div className="block sm:hidden w-full">
-                        <div 
-                          className="relative w-full"
-                          style={{ 
-                            aspectRatio: AD_DIMENSIONS.topBanner.mobile.aspectRatio
-                          }}
-                        >
-                          <div className="absolute inset-0">
-                            <CarouselAd ad={ad} forceMobile={false} />
-                          </div>
-                        </div>
-                      </div>
-                      {/* Desktop Banner */}
-                      <div className="hidden sm:block w-full">
-                        <div 
-                          className="relative mx-auto"
-                          style={{ 
-                            width: '100%',
-                            maxWidth: AD_DIMENSIONS.topBanner.desktop.width,
-                            aspectRatio: AD_DIMENSIONS.topBanner.desktop.aspectRatio
-                          }}
-                        >
-                          <div className="absolute inset-0">
-                            <CarouselAd ad={ad} forceMobile={false} />
-                          </div>
-                        </div>
-                      </div>
-                    </CarouselItem>
-                  ))}
-                </CarouselContent>
-              </Carousel>
-            </AdContainer>
+                <div
+                  className="relative overflow-hidden rounded-lg"
+                  style={{
+                    width: AD_DIMENSIONS.sideBanner.width,
+                    height: AD_DIMENSIONS.sideBanner.height
+                  }}
+                >
+                  <div className="inset-0">
+                    <VerticalCarousel ads={leftCarouselAds} />
+                  </div>
+                </div>
+              </AdContainer>
+            </div>
           )}
-
-          {/* Side Banners */}
-          <div className="hidden smlaptop:block">
-            {/* Left Banner */}
-            {leftCarouselAds.length > 0 && (
-              <div className="fixed left-4 top-1/3">
-                <AdContainer
-                  isLoading={isLeftCarouselLoading}
-                  skeleton={<SideBannerSkeleton />}
+        </div>
+      </div>
+      {/* Top Banner & Content*/}
+      <div className="mx-auto w-full max-w-4xl items-center p-4 below1550:max-w-6xl">
+        {shouldShowAds && (
+          <>
+            {topBannerAds.length > 0 && (
+              <AdContainer
+                isLoading={isTopBannerLoading}
+                skeleton={<TopBannerSkeleton />}
+                className="mb-4 w-full"
+              >
+                <Carousel
+                  className="w-full overflow-hidden rounded-lg"
+                  plugins={[topAutoPlayPlugin.current]}
                 >
-                  <div 
-                    className="relative overflow-hidden rounded-lg"
-                    style={{ 
-                      width: AD_DIMENSIONS.sideBanner.width,
-                      height: AD_DIMENSIONS.sideBanner.height
-                    }}
-                  >
-                    <div className="absolute inset-0">
-                      <VerticalCarousel ads={leftCarouselAds} />
-                    </div>
-                  </div>
-                </AdContainer>
-              </div>
+                  <CarouselContent>
+                    {topBannerAds.map((ad, index) => (
+                      <CarouselItem key={index} className="flex justify-center">
+                        {/* Mobile Banner */}
+                        <div className="block w-full sm:hidden">
+                          <div
+                            className="relative w-full"
+                            style={{
+                              aspectRatio:
+                                AD_DIMENSIONS.topBanner.mobile.aspectRatio
+                            }}
+                          >
+                            <div className="absolute inset-0">
+                              <CarouselAd ad={ad} forceMobile={false} />
+                            </div>
+                          </div>
+                        </div>
+                        {/* Desktop Banner */}
+                        <div className="hidden w-full sm:block">
+                          <div
+                            className="relative mx-auto"
+                            style={{
+                              width: '100%',
+                              maxWidth: AD_DIMENSIONS.topBanner.desktop.width,
+                              aspectRatio:
+                                AD_DIMENSIONS.topBanner.desktop.aspectRatio
+                            }}
+                          >
+                            <div className="absolute inset-0">
+                              <CarouselAd ad={ad} forceMobile={false} />
+                            </div>
+                          </div>
+                        </div>
+                      </CarouselItem>
+                    ))}
+                  </CarouselContent>
+                </Carousel>
+              </AdContainer>
             )}
+          </>
+        )}
+        {/* Page Content */}
+        <main className="z-10">{children}</main>
+      </div>
 
-            {/* Right Banner */}
-            {rightCarouselAds.length > 0 && (
-              <div className="fixed right-4 top-1/3">
-                <AdContainer
-                  isLoading={isRightCarouselLoading}
-                  skeleton={<SideBannerSkeleton />}
+      {/* Right Banner */}
+      <div className="container hidden w-full max-w-4xl flex-1 p-4 smlaptop:block">
+        <div className="sticky top-1/3 hidden smlaptop:block">
+          {rightCarouselAds.length > 0 && (
+            <div className="flex w-full justify-end">
+              <AdContainer
+                isLoading={isRightCarouselLoading}
+                skeleton={<SideBannerSkeleton />}
+              >
+                <div
+                  className="relative overflow-hidden rounded-lg"
+                  style={{
+                    width: AD_DIMENSIONS.sideBanner.width,
+                    height: AD_DIMENSIONS.sideBanner.height
+                  }}
                 >
-                  <div 
-                    className="relative overflow-hidden rounded-lg"
-                    style={{ 
-                      width: AD_DIMENSIONS.sideBanner.width,
-                      height: AD_DIMENSIONS.sideBanner.height
-                    }}
-                  >
-                    <div className="absolute inset-0">
-                      <VerticalCarousel ads={rightCarouselAds} />
-                    </div>
+                  <div className="inset-0">
+                    <VerticalCarousel ads={rightCarouselAds} />
                   </div>
-                </AdContainer>
-              </div>
-            )}
-          </div>
-        </>
-      )}
-
-      <main className="relative z-10">
-        {children}
-      </main>
+                </div>
+              </AdContainer>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,21 +1,26 @@
-import { DiscordLogoIcon, GitHubLogoIcon } from '@radix-ui/react-icons';
+import {
+  DiscordLogoIcon,
+  GitHubLogoIcon,
+  InstagramLogoIcon
+} from '@radix-ui/react-icons';
 import Link from 'next/link';
-import PoweredBy from '../powered-by';
 import useGlobalStore from '@/stores/globalStore';
 import { useAuth } from '@/hooks/useAuth';
+import { FacebookIcon } from 'lucide-react';
 
 export default function Footer() {
   const { adsEnabled } = useGlobalStore();
   const { isAuthenticated } = useAuth();
   return (
-    <footer className="bg-popover py-12 z-30">
+    <footer className="z-30 bg-popover py-6">
       <div className="container grid max-w-7xl grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-4">
-        <div className="grid gap-4">
+        <div className="grid content-start gap-2">
           <h3 className="text-lg font-semibold">Pages</h3>
           <nav className="grid gap-2">
             <Link href="/">Home</Link>
-            <Link href="/multisearch">Multisearch</Link>
-            <Link href="/about">About</Link>
+            <Link href="/multisearch">Multi Search</Link>
+            <Link href="/sealed">Sealed Search</Link>
+            <Link href="/buylists">Buylists</Link>
             {!isAuthenticated ? (
               <Link href="/signin">Login</Link>
             ) : (
@@ -23,15 +28,16 @@ export default function Footer() {
             )}
           </nav>
         </div>
-        <div className="grid gap-4">
+        <div className="grid content-start gap-2">
           <h3 className="text-lg font-semibold">Resources</h3>
           <nav className="grid gap-2">
+            <Link href="/about">About</Link>
             <Link href="/faq">FAQ</Link>
             <Link href="/privacy">Privacy</Link>
             <Link href="/terms">Terms</Link>
           </nav>
         </div>
-        <div className="grid gap-4">
+        <div className="grid content-start gap-2">
           <h3 className="text-lg font-semibold">Connect</h3>
           <div className="flex gap-4">
             <Link aria-label="Discord" href="https://discord.gg/EnKKHxSq75">
@@ -40,15 +46,20 @@ export default function Footer() {
             <Link aria-label="GitHub" href="https://github.com/bryceeppler">
               <GitHubLogoIcon className="h-6 w-6" />
             </Link>
+            <Link
+              aria-label="Instagram"
+              href="https://www.instagram.com/snapcasterca/"
+            >
+              <InstagramLogoIcon className="h-6 w-6" />
+            </Link>
+            <Link
+              aria-label="Facebook"
+              href="https://www.facebook.com/profile.php?id=61570086781596"
+            >
+              <FacebookIcon className="h-6 w-6" />
+            </Link>
           </div>
         </div>
-        {adsEnabled && (
-          <div className="flex items-start justify-end">
-            <div className="flex items-center gap-2">
-              {/* <PoweredBy size="medium" /> */}
-            </div>
-          </div>
-        )}
       </div>
     </footer>
   );

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -182,20 +182,6 @@ const Navbar: React.FC = () => {
                         Sealed Search
                       </Button>
                     </Link>
-                    <Link
-                      href="https://discord.gg/EnKKHxSq75"
-                      as="https://discord.gg/EnKKHxSq75"
-                    >
-                      <Button
-                        variant="ghost"
-                        className="block w-full text-left text-lg"
-                        onClick={() => {
-                          setMobileNavSheetOpen(false);
-                        }}
-                      >
-                        Discord
-                      </Button>
-                    </Link>
                     <Link href="/buylists" as="/buylists">
                       <Button
                         variant="ghost"
@@ -218,6 +204,21 @@ const Navbar: React.FC = () => {
                         About
                       </Button>
                     </Link>
+                    <Link
+                      href="https://discord.gg/EnKKHxSq75"
+                      as="https://discord.gg/EnKKHxSq75"
+                    >
+                      <Button
+                        variant="ghost"
+                        className="block w-full text-left text-lg"
+                        onClick={() => {
+                          setMobileNavSheetOpen(false);
+                        }}
+                      >
+                        Discord
+                      </Button>
+                    </Link>
+
                     {canViewAnalytics && (
                       <Link href="/vendors/dashboard" as="/vendors/dashboard">
                         <Button


### PR DESCRIPTION
**Purpose:**
Adjusted the main page layout to prevent overlapping the side banner with the footer. Updated our socials (FB & Instagram) into our footer. Reordered items listed in the mobile nav and footer.

**Relevant Filed Changed:**
- components/main-page-layout.tsx
- components/ui/footer.tsx
- components/ui/navbar.tsx

**Adjusted the main page layout to prevent overlapping the side banner with the footer:**
Description: Restructured the layout into a flex container where the left container is the left banner, the middle container is the top banner and page contents (the children), and the right container contains the right banner. The resizing and padding behavior remain the same but now the side banners don't clip into the footer anymore.
