### PR TITLE
buylists - updated infinite scroll trigger padding and ad padding

### DIFF
--- a/components/buylists/buylist-catalog-container.tsx
+++ b/components/buylists/buylist-catalog-container.tsx
@@ -9,7 +9,7 @@ import {
 import { CurrentListHeader } from './header/header';
 
 export default function BuylistCatalog() {
-  const { buylistUIState, setBuylistUIState } = useBuyListStore();
+  const { buylistUIState } = useBuyListStore();
   return (
     <div className="flex min-h-svh  flex-col  ">
       {/* Desktop Header */}

--- a/components/buylists/search-results/search-results.tsx
+++ b/components/buylists/search-results/search-results.tsx
@@ -116,7 +116,7 @@ export const BuylistSearchResults = () => {
         </div>
         <div
           ref={loadMoreRef}
-          className="h-[200svh] w-full"
+          className="h-[100svh] w-full"
           onClick={() => {
             setShouldReinitObserver(true);
           }}

--- a/components/main-page-layout.tsx
+++ b/components/main-page-layout.tsx
@@ -50,7 +50,7 @@ export default function MainLayout({
 
   return (
     <AdManagerProvider positionVendorWeights={positionVendorWeights}>
-      <div className="flex min-h-svh justify-center">
+      <div className="flex min-h-svh justify-center py-4">
         {/* Side Banners are now overlays and don't need container divs */}
         {shouldShowAds && usesSideBanners && (
           <>
@@ -63,7 +63,7 @@ export default function MainLayout({
         <div className="w-full max-w-4xl items-center px-4 below1550:max-w-6xl">
           {shouldShowAds && <TopBanner className="w-full" />}
           {/* Page Content */}
-          <main>{children}</main>
+          <main className="py-4">{children}</main>
         </div>
       </div>
     </AdManagerProvider>


### PR DESCRIPTION
**Purpose:** The side banners have a padding of 4 so I just added the same padding for the main layout content and the top ad banner so they're not straight up pressed against each other and the header. Also slimmed down the infinite scroll trigger padding in buylists because it was excessive on mobile if you scrolled too fast.