### PR TITLE
mainlayout bottom padding and fixed hidden buylist navbar bug fix

### DIFF
--- a/components/main-page-layout.tsx
+++ b/components/main-page-layout.tsx
@@ -67,7 +67,7 @@ export default function MainLayout({
             </div>
           )}
           {/* Page Content */}
-          <main className="pt-4">{children}</main>
+          <main className="py-4">{children}</main>
         </div>
       </div>
     </AdManagerProvider>

--- a/components/ui/navbar.tsx
+++ b/components/ui/navbar.tsx
@@ -210,7 +210,7 @@ const Navbar: React.FC = () => {
               })}
             </div>
           )}
-          {currentPath === '/buylists' && isAuthenticated && (
+          {currentPath === '/buylists' && (
             <div
               className={`fixed left-0 top-0 z-50 flex h-[48px] w-full items-center justify-between bg-background text-white transition-transform duration-500 md:px-2 ${
                 mobileSearchIsVisible ? 'translate-y-0' : '-translate-y-full'
@@ -259,7 +259,6 @@ const Navbar: React.FC = () => {
             {currentPath === '/' &&
               NavSearchBarFactory('singles', { deviceType: 'desktop' })}
             {currentPath === '/buylists' &&
-              isAuthenticated &&
               NavSearchBarFactory('buylists', { deviceType: 'desktop' })}
             {currentPath === '/sealed' &&
               NavSearchBarFactory('sealed', { deviceType: 'desktop' })}


### PR DESCRIPTION
**Purpose:** Forgot to remove the isAuthenticated check that hides the buylist nav search bar (we now let users query when they're not logged in now). Added bottom padding of 4 to the mainlayout.