### PR TITLE
connected vendor bug - disabling buylists

### DIFF
--- a/pages/buylists/index.tsx
+++ b/pages/buylists/index.tsx
@@ -3,6 +3,8 @@ import Head from 'next/head';
 import { NextPage } from 'next';
 import BackToTopButton from '@/components/ui/back-to-top-btn';
 import BuylistCatalog from '@/components/buylists/buylist-catalog-container';
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 type Props = {};
 const Buylist: NextPage<Props> = () => {
@@ -10,8 +12,22 @@ const Buylist: NextPage<Props> = () => {
     <>
       <BuylistHead />
       <div className="h-full min-h-svh ">
-        <BuylistCatalog />
-        <BackToTopButton />
+        <div className="flex flex-col items-center justify-center gap-2 pt-[calc(25vh-2rem)]">
+          <AlertCircle></AlertCircle>
+          <div className="flex flex-col items-center justify-center">
+            <p className="text-lg font-semibold">
+              Buylists is currently under maintenance
+            </p>
+            <p className="text-sm text-muted-foreground">
+              This feature will return in the next few days
+            </p>
+            <a href="https://discord.gg/EnKKHxSq75">
+              <Button className="mt-2 w-full">Discord Updates</Button>
+            </a>
+          </div>
+        </div>
+        {/* <BuylistCatalog />
+        <BackToTopButton /> */}
       </div>
     </>
   );


### PR DESCRIPTION
**Purpose:** Disabling buylists until we can get our new chrome extension version published.