### PR TITLE
added urlBuilder logic for singles/sealed/multi

### DIFF
--- a/components/multi-search/recommended-stores.tsx
+++ b/components/multi-search/recommended-stores.tsx
@@ -23,6 +23,7 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@/components/ui/tooltip';
+import { useDiscounts } from '@/hooks/queries/useDiscounts';
 import { useVendors } from '@/hooks/queries/useVendors';
 import { VendorAssetTheme, VendorAssetType } from '@/services/vendorService';
 import useMultiSearchStore from '@/stores/multiSearchStore';
@@ -36,12 +37,13 @@ export const RecommendedStores = () => {
   const { results } = useMultiSearchStore();
   const { getVendorNameBySlug, vendors } = useVendors();
   const { theme } = useTheme();
-
+  const { getLargestActiveDiscountByVendorSlug } = useDiscounts();
   // Filter out null values and then get unique card names
   const allCardNames = new Set(
     results.filter((group) => group && group[0]).map((group) => group[0]?.name)
   );
 
+  //Note: Reccomended Stores are just applicable to shopify stores for now. There is no logic in the buildCartUpdateUrls function that supports crystal or conduct stores for 1 click checkout.
   const reccomendedWebsites = [
     'obsidian',
     'levelup',
@@ -118,17 +120,17 @@ export const RecommendedStores = () => {
         sortedWebsites = [obsidianSite, ...sortedWebsites];
       }
     }
-
     return sortedWebsites;
   };
 
   const handleCheckout = (products: Product[]) => {
     if (products.length === 0) return;
-
     // Group products by host and build cart URLs
+    const discount = getLargestActiveDiscountByVendorSlug(
+      products[0]?.vendor || ''
+    );
     const groupedProducts = groupProductsByHost(products);
-    const cartUrls = buildCartUpdateUrls(groupedProducts);
-    // Open the first URL (there should only be one per vendor)
+    const cartUrls = buildCartUpdateUrls(groupedProducts, discount?.code);
     if (cartUrls.length > 0) {
       window.open(cartUrls[0], '_blank');
     }

--- a/components/multi-search/toolbar.tsx
+++ b/components/multi-search/toolbar.tsx
@@ -16,6 +16,10 @@ import {
 import { useVendors } from '@/hooks/queries/useVendors';
 import useMultiSearchStore from '@/stores/multiSearchStore';
 import type { Product } from '@/types';
+import { createConductUrlBuilder } from '@/utils/urlBuilders/conductUrlBuilder';
+import { createCrystalUrlBuilder } from '@/utils/urlBuilders/crystalUrlBuilder';
+import { createShopifyUrlBuilder } from '@/utils/urlBuilders/shopifyUrlBuilder';
+import { UtmPresets } from '@/utils/urlBuilders/urlBuilderInterfaces';
 export const Toolbar = () => {
   const { resetSearch, cart } = useMultiSearchStore();
   const { getVendorNameBySlug } = useVendors();
@@ -54,7 +58,20 @@ export const Toolbar = () => {
                 2
               )}\n  Set: ${product.set}\n  Condition: ${
                 product.condition
-              }\n  Link: ${product.link}\n`
+              }\n  Link: ${
+                product.platform === 'shopify'
+                  ? createShopifyUrlBuilder(product.link)
+                      .setProduct(product.handle, product.variant_id)
+                      .setUtmParams(UtmPresets.singles)
+                      .build()
+                  : product.platform === 'crystal'
+                  ? createCrystalUrlBuilder(product.link)
+                      .setUtmParams(UtmPresets.singles)
+                      .build()
+                  : createConductUrlBuilder(product.link)
+                      .setUtmParams(UtmPresets.singles)
+                      .build()
+              }\n`
           )
           .join('\n');
         return `Website: ${vendor}\n\n${productsText}`;

--- a/pages/multisearch/[tcgPath].tsx
+++ b/pages/multisearch/[tcgPath].tsx
@@ -254,7 +254,9 @@ const SearchView = ({
         </div>
 
         <div className="mx-auto max-w-xs text-center text-sm text-muted-foreground">
-          Search up to 100 cards at once. Paste your decklist in below!
+          {`Search up to ${
+            hasActiveSubscription ? '100' : '10'
+          } cards at once. Paste your decklist in below!`}
         </div>
         {!hasActiveSubscription && (
           <div>

--- a/utils/cartUrlBuilder.ts
+++ b/utils/cartUrlBuilder.ts
@@ -50,7 +50,7 @@ export function buildCartUpdateUrls(
   if (products[0]?.platform === 'shopify') {
     const shopifyBuilder = createShopifyUrlBuilder(baseUrl)
       .setCart(cartItems)
-      .setUtmParams(UtmPresets.singles);
+      .setUtmParams(UtmPresets.multi);
 
     if (discountCode) {
       shopifyBuilder.setDiscount(discountCode);

--- a/utils/cartUrlBuilder.ts
+++ b/utils/cartUrlBuilder.ts
@@ -1,3 +1,6 @@
+import { createShopifyUrlBuilder } from './urlBuilders/shopifyUrlBuilder';
+import { UtmPresets } from './urlBuilders/urlBuilderInterfaces';
+
 import type { Product } from '@/types';
 
 export function groupProductsByHost(
@@ -21,19 +24,42 @@ export function groupProductsByHost(
   }, {});
 }
 
-function buildUpdateParameters(products: Product[]): string {
-  return products
-    .map((product) => `updates[${product.variant_id}]=1`)
-    .join('&');
-}
-
+/**
+ * Multi Search Specific Url Builder
+ * Purpose: Build the cart update urls for the grouped products. We apply the cart items, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the cart checkout page with the discount code applied and UTM parameters applied
+ */
 export function buildCartUpdateUrls(
-  groupedProducts: Record<string, Product[]>
+  groupedProducts: Record<string, Product[]>,
+  discountCode?: string
 ): string[] {
-  const utmParams =
-    'utm_source=sc&utm_medium=referral&utm_campaign=referral_multisearch';
-  return Object.entries(groupedProducts).map(([host, products]) => {
-    const queryParams = buildUpdateParameters(products);
-    return `https://${host}/cart/update?${queryParams}&${utmParams}`;
-  });
+  const entries = Object.entries(groupedProducts);
+  if (entries.length === 0) return [];
+
+  const firstEntry = entries[0];
+  if (!firstEntry) return [];
+
+  const [host, products] = firstEntry;
+  const baseUrl = `https://${host}/`;
+
+  const cartItems = products
+    .filter((product) => product.variant_id)
+    .map((product) => ({
+      variantId: product.variant_id!.toString(),
+      quantity: 1
+    }));
+  if (products[0]?.platform === 'shopify') {
+    const shopifyBuilder = createShopifyUrlBuilder(baseUrl)
+      .setCart(cartItems)
+      .setUtmParams(UtmPresets.singles);
+
+    if (discountCode) {
+      shopifyBuilder.setDiscount(discountCode);
+    }
+
+    const shopifyUrl = shopifyBuilder.build();
+
+    return [shopifyUrl];
+  } else {
+    return [baseUrl];
+  }
 }

--- a/utils/urlBuilders/conductUrlBuilder.ts
+++ b/utils/urlBuilders/conductUrlBuilder.ts
@@ -1,0 +1,72 @@
+import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
+
+/**
+ * Single Conduct Commerce URL Builder
+ * Use Case: Build Crystal Commerce shopify URLs with product or cart paths, discounts, and UTM parameters
+ */
+export class ConductUrlBuilder {
+  private config: ShopifyUrlConfig;
+
+  constructor(baseUrl: string) {
+    this.config = { baseUrl, type: 'product' };
+  }
+
+  /**
+   * ConductUrlBuilder updates it's UTM parameters fields before building the url
+   * Purpose: Set the UTM parameters for the url builder. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  setUtmParams(params: UtmParams): ConductUrlBuilder {
+    if (params.utm_source) this.config.utmSource = params.utm_source;
+    if (params.utm_medium) this.config.utmMedium = params.utm_medium;
+    if (params.utm_campaign) this.config.utmCampaign = params.utm_campaign;
+    return this;
+  }
+
+  /**
+   * Build the UTM parameters
+   * Purpose: Build the UTM parameters for the url. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  private buildUtmParams(): string {
+    const params: string[] = [];
+    if (this.config.utmSource)
+      params.push(`utm_source=${this.config.utmSource}`);
+    if (this.config.utmMedium)
+      params.push(`utm_medium=${this.config.utmMedium}`);
+    if (this.config.utmCampaign)
+      params.push(`utm_campaign=${this.config.utmCampaign}`);
+    return params.join('&');
+  }
+
+  /**
+   * Build the product page url
+   * Purpose: Build the product page url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  private buildProductUrl(): string {
+    let url = this.config.baseUrl;
+
+    // Add UTM parameters
+    const utmParams = this.buildUtmParams();
+    if (utmParams) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += separator + utmParams;
+    }
+
+    return url;
+  }
+
+  /**
+   * Build the final URL
+   * Purpose: Build the final url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  build(): string {
+    return this.buildProductUrl();
+  }
+}
+
+/**
+ * Create a new ConductUrlBuilder
+ * Purpose: Create a new ConductUrlBuilder. We apply the base url to the url builder so that we can build the url for the product page or cart checkout page
+ */
+export function createConductUrlBuilder(baseUrl: string): ConductUrlBuilder {
+  return new ConductUrlBuilder(baseUrl);
+}

--- a/utils/urlBuilders/conductUrlBuilder.ts
+++ b/utils/urlBuilders/conductUrlBuilder.ts
@@ -1,8 +1,8 @@
 import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
 
 /**
- * Single Conduct Commerce URL Builder
- * Use Case: Build Crystal Commerce shopify URLs with product or cart paths, discounts, and UTM parameters
++ * Conduct Platform URL Builder
++ * Use Case: Build Conduct URLs with UTM parameters
  */
 export class ConductUrlBuilder {
   private config: ShopifyUrlConfig;
@@ -38,8 +38,8 @@ export class ConductUrlBuilder {
   }
 
   /**
-   * Build the product page url
-   * Purpose: Build the product page url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
++   * Build the product URL with UTM parameters
++   * Purpose: Build the product URL by appending UTM parameters to the base URL
    */
   private buildProductUrl(): string {
     let url = this.config.baseUrl;
@@ -55,8 +55,8 @@ export class ConductUrlBuilder {
   }
 
   /**
-   * Build the final URL
-   * Purpose: Build the final url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
++   * Build the final URL with UTM parameters
++   * Purpose: Build the final URL by appending UTM parameters to the base URL
    */
   build(): string {
     return this.buildProductUrl();

--- a/utils/urlBuilders/conductUrlBuilder.ts
+++ b/utils/urlBuilders/conductUrlBuilder.ts
@@ -1,11 +1,11 @@
-import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
+import type { ConductUrlConfig, UtmParams } from './urlBuilderInterfaces';
 
 /**
 + * Conduct Platform URL Builder
 + * Use Case: Build Conduct URLs with UTM parameters
  */
 export class ConductUrlBuilder {
-  private config: ShopifyUrlConfig;
+  private config: ConductUrlConfig;
 
   constructor(baseUrl: string) {
     this.config = { baseUrl, type: 'product' };

--- a/utils/urlBuilders/crystalUrlBuilder.ts
+++ b/utils/urlBuilders/crystalUrlBuilder.ts
@@ -1,0 +1,72 @@
+import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
+
+/**
+ * Single Crystal Commerce URL Builder
+ * Use Case: Build Crystal Commerce shopify URLs with product or cart paths, discounts, and UTM parameters
+ */
+export class CrystalUrlBuilder {
+  private config: ShopifyUrlConfig;
+
+  constructor(baseUrl: string) {
+    this.config = { baseUrl, type: 'product' };
+  }
+
+  /**
+   * CrystalUrlBuilder updates it's UTM parameters fields before building the url
+   * Purpose: Set the UTM parameters for the url builder. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  setUtmParams(params: UtmParams): CrystalUrlBuilder {
+    if (params.utm_source) this.config.utmSource = params.utm_source;
+    if (params.utm_medium) this.config.utmMedium = params.utm_medium;
+    if (params.utm_campaign) this.config.utmCampaign = params.utm_campaign;
+    return this;
+  }
+
+  /**
+   * Build the UTM parameters
+   * Purpose: Build the UTM parameters for the url. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  private buildUtmParams(): string {
+    const params: string[] = [];
+    if (this.config.utmSource)
+      params.push(`utm_source=${this.config.utmSource}`);
+    if (this.config.utmMedium)
+      params.push(`utm_medium=${this.config.utmMedium}`);
+    if (this.config.utmCampaign)
+      params.push(`utm_campaign=${this.config.utmCampaign}`);
+    return params.join('&');
+  }
+
+  /**
+   * Build the product page url
+   * Purpose: Build the product page url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  private buildProductUrl(): string {
+    let url = this.config.baseUrl;
+
+    // Add UTM parameters
+    const utmParams = this.buildUtmParams();
+    if (utmParams) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += separator + utmParams;
+    }
+
+    return url;
+  }
+
+  /**
+   * Build the final URL
+   * Purpose: Build the final url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  build(): string {
+    return this.buildProductUrl();
+  }
+}
+
+/**
+ * Create a new CrystalUrlBuilder
+ * Purpose: Create a new CrystalUrlBuilder. We apply the base url to the url builder so that we can build the url for the product page or cart checkout page
+ */
+export function createCrystalUrlBuilder(baseUrl: string): CrystalUrlBuilder {
+  return new CrystalUrlBuilder(baseUrl);
+}

--- a/utils/urlBuilders/crystalUrlBuilder.ts
+++ b/utils/urlBuilders/crystalUrlBuilder.ts
@@ -1,11 +1,11 @@
-import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
+import type { CrystalUrlConfig, UtmParams } from './urlBuilderInterfaces';
 
 /**
  * Single Crystal Commerce URL Builder
  * Use Case: Build Crystal Commerce shopify URLs with product or cart paths, discounts, and UTM parameters
  */
 export class CrystalUrlBuilder {
-  private config: ShopifyUrlConfig;
+  private config: CrystalUrlConfig;
 
   constructor(baseUrl: string) {
     this.config = { baseUrl, type: 'product' };

--- a/utils/urlBuilders/readme.txt
+++ b/utils/urlBuilders/readme.txt
@@ -1,0 +1,63 @@
+Last Updated July 14 205
+
+Purpose: We are now handleing url building client side. We were applying things like utm parameters serverside in the past but now we want to do it here.
+/utils/urlBuilders will determine the structure of outbound links to product and cart pages as well as apply discounts, product handles, product variant_ids, utm params, affilation tokens (when the shopify app is live)
+
+
+Updates To ES Schemas:
+- Each ES document stores a platform field: shopify | crystal | conduct which is used for what builder we want to used
+- Shopify ES Documents have a handle field which is used to build the url that redirects  to the product page
+- Shopify ES Documents link field is the base url of the website now. URL building now happens in the client.
+
+Shopify URL Builder Checklist:
+(TO DO) Sealed Search uses the url builder and applies the product handle, variant, discount redirect, and utm parameter
+(Done) Single Search uses the url builder and applies the product handle, variant, discount redirect, and utm parameter
+(Done) Multi Search uses the url builder and applies the product handle, variant, discount redirect, and utm parameter
+
+
+Crystal Commerce Completed Checklist:
+(Note) Currently unsure if we can even accomodate one click checkout for crystal commerce
+(Note) the link field in a crystal commerce document is the actual product page unlike for shopify where its the base url
+(Note) Honestly we might be able to to deprecate multi search if we make the site like skinport where people can add to cart and save their items.
+(Note) Multi Search Reccomended stores is not applicable
+(Done) Crystal URL Builder appends the url parameter
+
+//////////////////////////
+// Shopify URL Examples //
+//////////////////////////
+
+(1) Url Builder Order of operations:
+Note: Discount and the discounts (1) products (2) and cart (3) paths are not applicable to non shopify platforms
+- 1. discounts redirect => /discount/{discount_code}?redirect={products path or cart path} (Optional)
+- 2.1 (Either products path or cart path) => /products/{product_handle}?variant={variant_id}
+- 2.2 (Either products path or cart path) => /cart/{variant_id1}:{quantity},{variant_id2}:{quantity}
+- 3. utm params (utm_source) => &utm_source={source}
+- 4. utm params (utm_medium) => &utm_medium={medium}
+- 5. utm params (utm_campaign) => &utm_campaign={campaign}
+- 6. (Coming Soon) attribution token parameter on the /cart permalink once we have the shopify app ready
+
+
+(2)Example Urls
+- (product page) => /discount/OBSIDIAN+SNAPCASTER5?redirect=/products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531&utm_source=sc&utm_medium=referral&utm_campaign=referral_singles
+- (checkout page) => /discount/OBSIDIAN+SNAPCASTER5?redirect=/cart/43629330202819:1,43346607866051:1&utm_source=sc&utm_medium=referral&utm_campaign=referral_singles
+
+
+(3) product page variations (brings straight to the product page)
+- (visit product page (product handle plus vairiant id)) => /products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531
+- (add utm source param) => /products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531&utm_source=sc
+- (add utm medium param) => /products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531&utm_medium=referral
+- (add utm utm_campaign param) => /products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531&utm_campaign=referral_singles
+- (add utm utm_campaign param) => /products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531&utm_source=sc&utm_medium=referral&utm_campaign=referral_singles
+- (add discount code and redirect (gets auto applied on the user session so if they it gets applied and they can add to cart later)) => /discount/OBSIDIAN+SNAPCASTER5?redirect=/products/shambling-shell-ravnica-city-of-guilds?variant=42703019278531
+
+(4) checkout page variations (brings straight to the checkout page)
+Note: The checkout page will only have the items listed in the url meaning we don't have to worry about clearing the cart items then reapplying in case the user wants to make adjustments to the cart
+- (cart with added items) => /cart/43629330202819:1,43346607866051:1
+- (dicount code redirect to cart page) => /discount/OBSIDIAN+SNAPCASTER5?redirect=/cart/43629330202819:1,43346607866051:1
+- (applying utm params to cart page) => /discount/OBSIDIAN+SNAPCASTER5?redirect=/cart/43629330202819:1,43346607866051:1&utm_source=sc&utm_medium=referral&utm_campaign=referral_singles
+
+////////////////////////////
+// Crystal/Conduct Stores //
+////////////////////////////
+- the link value will have the url to the actual product at the moment unlike shopify stores which will have the base url to the website so we can then build the url. As a result, utils/urlBuilders/conductUrlBuilder.ts and utils/urlBuilders/crystalUrlBuilder.ts simply have a function for just adding the utm parameters for now
+- Conduct Commerce and Crystal Commerce Stores dont seem to have a 1 click checkout url resource so multi search will not support it right now.

--- a/utils/urlBuilders/shopifyUrlBuilder.ts
+++ b/utils/urlBuilders/shopifyUrlBuilder.ts
@@ -1,0 +1,155 @@
+import type { ShopifyUrlConfig, UtmParams } from './urlBuilderInterfaces';
+
+/**
+ * Single/sealed/multi search Shopify URL Builder
+ * Purpose: Build Shopify URLs with product or cart paths, discounts, and UTM parameters
+ */
+export class ShopifyUrlBuilder {
+  private config: ShopifyUrlConfig;
+
+  constructor(baseUrl: string) {
+    this.config = { baseUrl, type: 'product' };
+  }
+
+  /**
+   * ShopifyUrlBuilder updates it's product page configuration before building the url
+   * Purpose: Set the product page configuration for the url builder. We apply the type (product or cart path), handle, and vairant id
+   */
+  setProduct(handle: string, variantId?: string): ShopifyUrlBuilder {
+    this.config.type = 'product';
+    this.config.productHandle = handle;
+    if (variantId !== undefined) {
+      this.config.variantId = variantId;
+    }
+    return this;
+  }
+
+  /**
+   * ShopifyUrlBuilder updates it's cart items field before building the url
+   * Purpose: Set the cart checkout page configuration for the url builder. We apply the type (product or cart path), and cart items that will show on the checkout screen on the vendors website
+   */
+  setCart(
+    items: Array<{ variantId: string; quantity: number }>
+  ): ShopifyUrlBuilder {
+    this.config.type = 'cart';
+    this.config.cartItems = items;
+    return this;
+  }
+
+  /**
+   * ShopifyUrlBuilder updates it's discount code field before building the url
+   * Purpose: Set the discount code for the url builder. We apply the discount code to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied
+   */
+  setDiscount(code: string): ShopifyUrlBuilder {
+    this.config.discountCode = code;
+    return this;
+  }
+
+  /**
+   * ShopifyUrlBuilder updates it's UTM parameters fields before building the url
+   * Purpose: Set the UTM parameters for the url builder. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  setUtmParams(params: UtmParams): ShopifyUrlBuilder {
+    if (params.utm_source) this.config.utmSource = params.utm_source;
+    if (params.utm_medium) this.config.utmMedium = params.utm_medium;
+    if (params.utm_campaign) this.config.utmCampaign = params.utm_campaign;
+    return this;
+  }
+
+  /**
+   * Build UTM parameters
+   * Purpose: Build the UTM parameters for the url. We apply the UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the UTM parameters applied
+   */
+  private buildUtmParams(): string {
+    const params: string[] = [];
+    if (this.config.utmSource)
+      params.push(`utm_source=${this.config.utmSource}`);
+    if (this.config.utmMedium)
+      params.push(`utm_medium=${this.config.utmMedium}`);
+    if (this.config.utmCampaign)
+      params.push(`utm_campaign=${this.config.utmCampaign}`);
+    return params.join('&');
+  }
+
+  /**
+   * Build the product page url
+   * Purpose: Build the product page url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  private buildProductUrl(): string {
+    let url = this.config.baseUrl;
+
+    // Build product path
+    let productPath = `products/${this.config.productHandle}`;
+    if (this.config.variantId) {
+      productPath += `?variant=${this.config.variantId}`;
+    }
+
+    // Add discount wrapper if needed
+    if (this.config.discountCode) {
+      url += `discount/${this.config.discountCode}`;
+      url += `?redirect=/${productPath}`;
+    } else {
+      url += productPath;
+    }
+
+    // Add UTM parameters
+    const utmParams = this.buildUtmParams();
+    if (utmParams) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += separator + utmParams;
+    }
+
+    return url;
+  }
+
+  /**
+   * Build the cart checkout page url
+   * Purpose: Build the cart checkout page url. We apply the cart path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the cart checkout page with the discount code applied and UTM parameters applied
+   */
+  private buildCartUrl(): string {
+    let url = this.config.baseUrl;
+
+    // Build cart path
+    const cartItemsString = this.config
+      .cartItems!.map((item) => `${item.variantId}:${item.quantity}`)
+      .join(',');
+    const cartPath = `cart/${cartItemsString}`;
+
+    // Add discount wrapper if needed
+    if (this.config.discountCode) {
+      url += `discount/${encodeURIComponent(this.config.discountCode)}`;
+      url += `?redirect=/${encodeURIComponent(cartPath)}`;
+    } else {
+      url += cartPath;
+    }
+
+    // Add UTM parameters
+    const utmParams = this.buildUtmParams();
+    if (utmParams) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += separator + utmParams;
+    }
+
+    return url;
+  }
+
+  /**
+   * Build the final URL
+   * Purpose: Build the final url. We apply the product path, discount code, and UTM parameters to the url so that when the user clicks the link, they are redirected to the product page with the discount code applied and UTM parameters applied
+   */
+  build(): string {
+    if (this.config.type === 'product') {
+      return this.buildProductUrl();
+    } else {
+      return this.buildCartUrl();
+    }
+  }
+}
+
+/**
+ * Create a new ShopifyUrlBuilder
+ * Purpose: Create a new ShopifyUrlBuilder. We apply the base url to the url builder so that we can build the url for the product page or cart checkout page
+ */
+export function createShopifyUrlBuilder(baseUrl: string): ShopifyUrlBuilder {
+  return new ShopifyUrlBuilder(baseUrl);
+}

--- a/utils/urlBuilders/urlBuilderInterfaces.ts
+++ b/utils/urlBuilders/urlBuilderInterfaces.ts
@@ -1,0 +1,60 @@
+/**
+ * Base configuration For URL Builder
+ * Purpose: Base configuration for URL Builder for attribution, utm params, cart info, product page info, and discount code redirects for shopify/crystal/conduct platform stores
+ */
+export interface BaseUrlConfig {
+  baseUrl: string;
+  discountCode?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+}
+
+/**
+ * Shopify-specific configuration
+ * Purpose: Build Shopify URLs with product or cart paths, discounts, and UTM parameters
+ */
+export interface ShopifyUrlConfig extends BaseUrlConfig {
+  type: 'product' | 'cart';
+  productHandle?: string;
+  variantId?: string | undefined; // Allow undefined
+  cartItems?: Array<{ variantId: string; quantity: number }>;
+}
+
+/**
+ * Crystal-specific configuration
+ * Purpose: Build Crystal URLs with productpage or cart checkout paths, apply discounts, and apply UTM parameters
+ */
+export interface CrystalUrlConfig extends BaseUrlConfig {
+  type: 'product' | 'cart';
+  productHandle?: string;
+  variantId?: string | undefined; // Allow undefined
+  cartItems?: Array<{ variantId: string; quantity: number }>;
+}
+export interface UtmParams {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+}
+
+/**
+ * Predefined UTM parameter sets for common use cases
+ * Purpose: Predefined UTM parameter sets for common outbound links for marketing attribution
+ */
+export const UtmPresets = {
+  singles: {
+    utm_source: 'sc',
+    utm_medium: 'referral',
+    utm_campaign: 'referral_singles'
+  },
+  sealed: {
+    utm_source: 'sc',
+    utm_medium: 'referral',
+    utm_campaign: 'referral_sealed'
+  },
+  multi: {
+    utm_source: 'sc',
+    utm_medium: 'referral',
+    utm_campaign: 'referral_multi'
+  }
+} as const;

--- a/utils/urlBuilders/urlBuilderInterfaces.ts
+++ b/utils/urlBuilders/urlBuilderInterfaces.ts
@@ -27,10 +27,16 @@ export interface ShopifyUrlConfig extends BaseUrlConfig {
  */
 export interface CrystalUrlConfig extends BaseUrlConfig {
   type: 'product' | 'cart';
-  productHandle?: string;
-  variantId?: string | undefined; // Allow undefined
-  cartItems?: Array<{ variantId: string; quantity: number }>;
 }
+
+/**
+ * Conduct-specific configuration
+ * Purpose: Build Conduct URLs with UTM parameters
+ */
+export interface ConductUrlConfig extends BaseUrlConfig {
+  type: 'product' | 'cart';
+}
+
 export interface UtmParams {
   utm_source?: string;
   utm_medium?: string;


### PR DESCRIPTION
**Purpose:** 
Moved url builder logic to the client.

**Description:** 
The backend used to send the url prebuilt with utm parameters and the path to the product for us. I added a folder with utility builder classes for shopify/crystal/conduct stores in /utils/urlBuilders that will create the link when the user hits the buy or checkout button for singles/sealed/multi. The catalog service was also applying the utm parameters for us in the results via the search endpoint in catalog so i removed the part that applies it because the client will handle it now.

**(1) Usage of the {platform}UrlBuilders in Singles/Multi/Sealed Search:**
- components/multi-search/recommended-stores.tsx => The recommended stores uses the improved checkout redirect now
-  components/multi-search/toolbar.tsx => Multisearch's export cart makes usage of the urlBuilders now.
- components/sealed/sealed-catalog-item.tsx => Sealed Catalog Cards ourbound link uses the urlBuilders now
- utils/cartUrlBuilder.ts => Multi Search Specific function that calls the urlBuilder. this is used in components/multi-search/recommended-stores.tsx
- components/single-search/single-catalog-item.tsx => Single Search Buy Button applies all parameters using the client side urlBuilders now


**(2) {platform}urlBuilder files and logic:**
- utils/urlBuilders/urlBuilderInterfaces.ts => Interfaces used by the platform specific builder classes (3 files listed below)
- utils/urlBuilders/conductUrlBuilder.ts => Create a builder object and add whatever fields you need then call the build function
- utils/urlBuilders/crystalUrlBuilder.ts => Create a builder object and add whatever fields you need then call the build function
- utils/urlBuilders/shopifyUrlBuilder.ts => Create a builder object and add whatever fields you need then call the build function

Note: crystalUrlBuilder and conductUrlBuilder just support adding the utm parameter for now since 1 click checkout isnt applicable to them. Shopify is more nuanced where the options are First create a product page or cart checkout link, second optionally add a discount code redirect if the store has one with us, and third apply the utm parameters. 

**To Do:**
1) This involved updating the scraper files for shopify/crystal/conduct because we were storing the product path as the link field. The Shopify scraper files now include a product handle field to make the url building easier. All Scrapers for sealed/singles in shopify/crystal/conduct now have a platform field. Because we wildcard index our ES indexes, having the document specify which eccomerce platform it's on makes the url building easier since its different by platform. You will need to go to the backend repo, push the pr to main on branch "SNAP-146-url-utility-class"
2) after its on main make sure the shopify, crystal, and conduct producers are up to date to prod and that they have ran.
3) You can then push this branch to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced platform-specific URL builders for Shopify, Crystal Commerce, and Conduct, enabling dynamic construction of product and cart URLs with UTM tracking and discount codes.
  * Added support for applying the largest active discount code for Shopify vendors during checkout and on product pages.
  * Enhanced outbound links and cart exports to consistently include UTM parameters for improved marketing attribution.
  * Updated search interface to display card search limits dynamically based on user subscription status.

* **Documentation**
  * Added comprehensive documentation outlining the client-side URL building strategy, platform-specific behaviors, and integration status.

* **Refactor**
  * Centralized and standardized URL construction logic across product pages, cart exports, and checkout flows.
  * Updated components to use platform-aware URL builders instead of static product links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->