### PR TITLE
Minor styling updates

### DIFF
--- a/components/navigation/desktop-navbar.tsx
+++ b/components/navigation/desktop-navbar.tsx
@@ -22,7 +22,7 @@ export default function DesktopNavbar(): JSX.Element {
   const canViewAnalytics = isAdmin || isVendor;
 
   return (
-    <header className="sticky top-0 z-40 hidden bg-background lg:block">
+    <header className="sticky top-0 z-40 hidden bg-background md:block">
       {/* Top section with logo, search and account */}
       <div className="relative border-b border-border/40">
         <div className="flex h-16 items-center justify-between px-6">

--- a/components/navigation/mobile-navbar.tsx
+++ b/components/navigation/mobile-navbar.tsx
@@ -95,10 +95,8 @@ export default function MobileNavbar(): JSX.Element {
 
   // Get cart data - only fetch when on buylists page
   const isOnBuylistsPage = currentPath.startsWith('/buylists');
-  const { getCurrentCart } = isOnBuylistsPage
-    ? useUserCarts()
-    : { getCurrentCart: () => null };
-  const currentCart = getCurrentCart();
+  const { getCurrentCart } = useUserCarts();
+  const currentCart = isOnBuylistsPage ? getCurrentCart() : null;
   const cartItemCount = currentCart?.cart?.items?.length || 0;
   const hasCartItems = cartItemCount > 0;
   const isCartVisible =

--- a/components/navigation/mobile-navbar.tsx
+++ b/components/navigation/mobile-navbar.tsx
@@ -95,13 +95,14 @@ export default function MobileNavbar(): JSX.Element {
 
   // Get cart data - only fetch when on buylists page
   const isOnBuylistsPage = currentPath.startsWith('/buylists');
-  const { getCurrentCart } = isOnBuylistsPage ? useUserCarts() : { getCurrentCart: () => null };
+  const { getCurrentCart } = isOnBuylistsPage
+    ? useUserCarts()
+    : { getCurrentCart: () => null };
   const currentCart = getCurrentCart();
   const cartItemCount = currentCart?.cart?.items?.length || 0;
   const hasCartItems = cartItemCount > 0;
   const isCartVisible =
-    isOnBuylistsPage &&
-    buylistUIState !== 'finalSubmissionState';
+    isOnBuylistsPage && buylistUIState !== 'finalSubmissionState';
   const isCartEnabled = Boolean(currentCart?.cart?.name);
 
   // Handle cart button click
@@ -195,7 +196,7 @@ export default function MobileNavbar(): JSX.Element {
   ];
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-background lg:hidden">
+    <header className="sticky top-0 z-50 border-b bg-background md:hidden">
       <nav
         className="relative flex justify-between px-3 py-2.5"
         aria-label="Mobile navigation"

--- a/components/navigation/search-bars/singles-search-bar.tsx
+++ b/components/navigation/search-bars/singles-search-bar.tsx
@@ -106,11 +106,26 @@ export default function SinglesSearchBar({
 
       case 'Enter':
         event.preventDefault();
-        clearFilters();
-        setIsLoading(true);
-        fetchCards();
-        setIsAutoCompleteVisible(false);
-        trackSearch('singles', searchTerm, tcg);
+        // If there's a selected suggestion, use that value
+        if (selectedIndex >= 0 && selectedIndex < totalResults) {
+          const selectedSuggestion = suggestions[selectedIndex];
+          setSearchTerm(selectedSuggestion?.name || '');
+          // Use setTimeout to ensure the state update happens before search
+          setTimeout(() => {
+            clearFilters();
+            setIsLoading(true);
+            fetchCards();
+            setIsAutoCompleteVisible(false);
+            trackSearch('singles', selectedSuggestion?.name || '', tcg);
+          }, 0);
+        } else {
+          // No suggestion selected, use current search term
+          clearFilters();
+          setIsLoading(true);
+          fetchCards();
+          setIsAutoCompleteVisible(false);
+          trackSearch('singles', searchTerm, tcg);
+        }
         break;
 
       case 'Escape':

--- a/components/navigation/toolbars/singles-results-toolbar.tsx
+++ b/components/navigation/toolbars/singles-results-toolbar.tsx
@@ -5,6 +5,7 @@ import { SlidersHorizontal } from 'lucide-react';
 import FilterSection from '@/components/search-ui/search-filter-container';
 import SearchPagination from '@/components/search-ui/search-pagination';
 import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Sheet,
   SheetContent,
@@ -13,7 +14,6 @@ import {
   SheetTrigger
 } from '@/components/ui/sheet';
 import { useSingleSearchStore } from '@/stores/useSingleSearchStore';
-import { ScrollArea } from '@/components/ui/scroll-area';
 
 /**
  * Toolbar component for singles search results

--- a/components/navigation/toolbars/singles-results-toolbar.tsx
+++ b/components/navigation/toolbars/singles-results-toolbar.tsx
@@ -13,6 +13,7 @@ import {
   SheetTrigger
 } from '@/components/ui/sheet';
 import { useSingleSearchStore } from '@/stores/useSingleSearchStore';
+import { ScrollArea } from '@/components/ui/scroll-area';
 
 /**
  * Toolbar component for singles search results
@@ -36,6 +37,14 @@ export default function SinglesResultsToolbar(): JSX.Element | null {
     sortByOptions
   } = useSingleSearchStore();
 
+  // Format results count
+  const formatResultsCount = (count: number): string => {
+    if (count >= 1000) {
+      return `${(count / 1000).toFixed(1)}k`;
+    }
+    return count.toString();
+  };
+
   // Only render if we have search results
   if (!searchResults) return null;
 
@@ -45,7 +54,7 @@ export default function SinglesResultsToolbar(): JSX.Element | null {
         className="text-center text-sm font-normal text-muted-foreground"
         aria-live="polite"
       >
-        {numResults} results
+        {formatResultsCount(numResults || 0)} results
       </span>
 
       <SearchPagination
@@ -69,26 +78,30 @@ export default function SinglesResultsToolbar(): JSX.Element | null {
           </Button>
         </SheetTrigger>
 
-        <SheetContent className="min-w-full">
-          <SheetTitle>Filters</SheetTitle>
-          <SheetDescription>Filter your search results</SheetDescription>
+        <SheetContent className="min-w-full p-2">
+          <ScrollArea className="flex max-h-[100svh] flex-col overflow-y-auto rounded">
+            <div className="flex flex-col p-6">
+              <SheetTitle>Filters</SheetTitle>
+              <SheetDescription>Filter your search results</SheetDescription>
 
-          <FilterSection
-            filterOptions={filterOptions || []}
-            sortBy={sortBy || ''}
-            fetchCards={fetchCards}
-            clearFilters={clearFilters}
-            setFilter={setFilter}
-            setCurrentPage={setCurrentPage}
-            handleSortByChange={(value: string) => {
-              setSortBy(value);
-              setCurrentPage(1);
-              fetchCards();
-            }}
-            applyFilters={applyFilters}
-            setSortBy={setSortBy}
-            sortByOptions={sortByOptions}
-          />
+              <FilterSection
+                filterOptions={filterOptions || []}
+                sortBy={sortBy || ''}
+                fetchCards={fetchCards}
+                clearFilters={clearFilters}
+                setFilter={setFilter}
+                setCurrentPage={setCurrentPage}
+                handleSortByChange={(value: string) => {
+                  setSortBy(value);
+                  setCurrentPage(1);
+                  fetchCards();
+                }}
+                applyFilters={applyFilters}
+                setSortBy={setSortBy}
+                sortByOptions={sortByOptions}
+              />
+            </div>
+          </ScrollArea>
         </SheetContent>
       </Sheet>
     </div>

--- a/components/sealed/sealed-catalog-container.tsx
+++ b/components/sealed/sealed-catalog-container.tsx
@@ -82,7 +82,7 @@ export default function SealedCatalogContainer({
       <div className="grid h-min gap-1">
         {/* #2.1 Single Search Top Bar Section (# Results, Pagination, Sort By) */}
         <div className="z-30 bg-background pt-1">
-          <div className="flex flex-row items-center justify-between rounded-lg bg-popover px-4 py-2">
+          <div className="flex flex-row items-center justify-between rounded-lg border bg-popover px-4 py-2">
             <div className="flex flex-col">
               <span className="text-center text-sm font-normal text-secondary-foreground">
                 {searchResults?.length} results

--- a/components/search-ui/search-filter-container.tsx
+++ b/components/search-ui/search-filter-container.tsx
@@ -55,64 +55,61 @@ const FilterSection: React.FC<FilterSectionProps> = memo(
       fetchCards();
     };
     return (
-      <ScrollArea className="flex max-h-[95svh] flex-col overflow-y-auto rounded">
-        <div className="sticky top-5 mx-auto h-1/4 w-full rounded-lg  px-3 py-2 text-left shadow-md md:max-w-sm">
-          <div className=" border-b ">
-            {/* {sortByOptions && <p>its here</p>} */}
-            <div className="flex w-full justify-center">
-              <SearchSortBy
-                sortBy={sortBy}
-                setSortBy={setSortBy}
-                fetchCards={fetchCards}
-                setCurrentPage={setCurrentPage}
-                sortByOptions={sortByOptions}
-              />
-            </div>
+      <div className="sticky top-5 mx-auto h-1/4 w-full rounded-lg py-2 text-left md:max-w-sm">
+        <div className=" border-b ">
+          <div className="flex w-full justify-center">
+            <SearchSortBy
+              sortBy={sortBy}
+              setSortBy={setSortBy}
+              fetchCards={fetchCards}
+              setCurrentPage={setCurrentPage}
+              sortByOptions={sortByOptions}
+            />
           </div>
-          <Accordion type="multiple" className="w-full  ">
-            {filterOptions &&
-              filterOptions.map((filterOption: FilterOption, i: number) => (
-                <AccordionItem value={filterOption.field} key={i}>
-                  <AccordionTrigger className="hover:no-underline">
-                    {filterOption.name}
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <FilterScrollArea
-                      key={filterOption.field}
-                      filterOption={filterOption}
-                      setFilter={setFilter}
-                      setCurrentPage={setCurrentPage}
-                      applyFilters={applyFilters}
-                    />
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-          </Accordion>
-          {!hasActiveSubscription && !hidePromo && (
-            <div className="border-1 mb-4 flex flex-col gap-2 border p-4 text-left text-sm">
-              <p>
-                Support us with{' '}
-                <span className="font-bold text-primary">Snapcaster Pro</span>{' '}
-                and remove promoted results with reduced ads for $2.99/mo.
-              </p>
-              <Button
-                onClick={
-                  isAuthenticated
-                    ? createCheckoutSession
-                    : () => (window.location.href = '/signin')
-                }
-              >
-                Subscribe
-              </Button>
-            </div>
-          )}
-
-          <Button onClick={handleClearFilters} className="w-full">
-            Clear Filters
-          </Button>
-          <Separator className="mx-2" />
         </div>
-      </ScrollArea>
+        <Accordion type="multiple" className="w-full">
+          {filterOptions &&
+            filterOptions.map((filterOption: FilterOption, i: number) => (
+              <AccordionItem value={filterOption.field} key={i}>
+                <AccordionTrigger className="hover:no-underline">
+                  {filterOption.name}
+                </AccordionTrigger>
+                <AccordionContent className="overflow-hidden">
+                  <FilterScrollArea
+                    key={filterOption.field}
+                    filterOption={filterOption}
+                    setFilter={setFilter}
+                    setCurrentPage={setCurrentPage}
+                    applyFilters={applyFilters}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+        </Accordion>
+        {!hasActiveSubscription && !hidePromo && (
+          <div className="border-1 mb-4 flex flex-col gap-2 border p-4 text-left text-sm">
+            <p>
+              Support us with{' '}
+              <span className="font-bold text-primary">Snapcaster Pro</span> and
+              remove promoted results with reduced ads for $2.99/mo.
+            </p>
+            <Button
+              onClick={
+                isAuthenticated
+                  ? createCheckoutSession
+                  : () => (window.location.href = '/signin')
+              }
+            >
+              Subscribe
+            </Button>
+          </div>
+        )}
+
+        <Button onClick={handleClearFilters} className="w-full">
+          Clear Filters
+        </Button>
+        <Separator className="mx-2" />
+      </div>
     );
   }
 );
@@ -131,9 +128,9 @@ const FilterScrollArea: React.FC<FilterScrollAreaProps> = ({
   applyFilters
 }) => {
   return (
-    <div>
-      <div className="flex">
-        <ScrollArea className="90 max-h-48 w-full rounded-lg  px-3">
+    <div className="w-full max-w-full">
+      <div className="flex w-full max-w-full">
+        <ScrollArea className="max-h-48 w-full max-w-full px-3">
           <FilterFactory
             filterOption={filterOption}
             setFilter={setFilter}
@@ -187,18 +184,25 @@ const FilterFactory: React.FC<FilterFactoryProps> = ({
   };
 
   return (
-    <div className="space-y-3 py-2">
+    <div className="w-full max-w-full space-y-3 py-2">
       {filterOption &&
         filterOption.values.map((option: FilterOptionValues) => (
-          <div key={option.value} className="flex items-start">
+          <div
+            key={option.value}
+            className="flex w-full max-w-full items-start"
+          >
             <input
               type="checkbox"
               id={option.value}
               checked={localSelections[option.value] ?? option.selected}
               onChange={() => handleOptionChange(filterOption, option)}
-              className="mr-2 mt-1"
+              className="mr-2 mt-1 flex-shrink-0"
             />
-            <label htmlFor={option.value} className="text-sm leading-5">
+            <label
+              htmlFor={option.value}
+              className="min-w-0 flex-1 break-words text-sm leading-5"
+              style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}
+            >
               {filterOption.field === 'vendor'
                 ? getVendorNameBySlug(option.value)
                 : option.label}{' '}

--- a/components/single-search/single-catalog-container.tsx
+++ b/components/single-search/single-catalog-container.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import SearchPagination from '../search-ui/search-pagination';
 import SearchSortBy from '../search-ui/search-sort-by';
 import BackToTopButton from '../ui/back-to-top-btn';
+import { ScrollArea } from '../ui/scroll-area';
 
 import SingleCatalogItem from './single-catalog-item';
 
@@ -15,7 +16,6 @@ import type { AdvertisementWithImages } from '@/types/advertisements';
 import { AdvertisementPosition } from '@/types/advertisements';
 import { appendUtmParameters } from '@/utils/adUrlBuilder';
 import { createWeightedSelectionManager } from '@/utils/weightedSelection';
-import { ScrollArea } from '../ui/scroll-area';
 
 // Constant defining how often ads should appear in search results
 const AD_INTERVAL = 10;

--- a/components/single-search/single-catalog-container.tsx
+++ b/components/single-search/single-catalog-container.tsx
@@ -15,6 +15,7 @@ import type { AdvertisementWithImages } from '@/types/advertisements';
 import { AdvertisementPosition } from '@/types/advertisements';
 import { appendUtmParameters } from '@/utils/adUrlBuilder';
 import { createWeightedSelectionManager } from '@/utils/weightedSelection';
+import { ScrollArea } from '../ui/scroll-area';
 
 // Constant defining how often ads should appear in search results
 const AD_INTERVAL = 10;
@@ -184,6 +185,15 @@ export default function SingleCatalog() {
     setCurrentPage(1);
     fetchCards();
   };
+
+  // Format results count
+  const formatResultsCount = (count: number): string => {
+    if (count >= 1000) {
+      return `${(count / 1000).toFixed(1)}k`;
+    }
+    return count.toString();
+  };
+
   return (
     <div className="mb-8 grid min-h-svh gap-1 md:grid-cols-[240px_1fr]">
       {/* #1 Single Search Filter Section */}
@@ -196,33 +206,36 @@ export default function SingleCatalog() {
           {!loadingFilterResults && filters && (
             <div className="relative  hidden w-full flex-col gap-1 md:flex">
               <div className="child-1 mt-1 w-full md:sticky md:top-[118px]">
-                <Card className="bg-popover pt-4 md:max-w-sm">
-                  <CardContent className="text-left">
-                    <div className="mx-auto w-full">
-                      <div className="sm:hidden">
-                        <SearchSortBy
+                <Card className="bg-popover pt-2 md:max-w-sm ">
+                  <div className="p-1">
+                    <ScrollArea className="flex max-h-[80svh] flex-col overflow-y-auto rounded pr-2 ">
+                      <CardContent className="px-3 text-left">
+                        <div className="mx-auto w-full">
+                          <div className="sm:hidden">
+                            <SearchSortBy
+                              sortBy={sortBy || ''}
+                              sortByOptions={sortByOptions}
+                              setSortBy={setSortBy}
+                              fetchCards={fetchCards}
+                              setCurrentPage={setCurrentPage}
+                            />
+                          </div>
+                        </div>
+                        <FilterSection
+                          filterOptions={filterOptions || []}
                           sortBy={sortBy || ''}
-                          sortByOptions={sortByOptions}
                           setSortBy={setSortBy}
                           fetchCards={fetchCards}
+                          clearFilters={clearFilters}
+                          setFilter={setFilter}
                           setCurrentPage={setCurrentPage}
+                          handleSortByChange={handleSortByChange}
+                          applyFilters={applyFilters}
+                          sortByOptions={sortByOptions}
                         />
-                      </div>
-                    </div>
-
-                    <FilterSection
-                      filterOptions={filterOptions || []}
-                      sortBy={sortBy || ''}
-                      setSortBy={setSortBy}
-                      fetchCards={fetchCards}
-                      clearFilters={clearFilters}
-                      setFilter={setFilter}
-                      setCurrentPage={setCurrentPage}
-                      handleSortByChange={handleSortByChange}
-                      applyFilters={applyFilters}
-                      sortByOptions={sortByOptions}
-                    />
-                  </CardContent>
+                      </CardContent>
+                    </ScrollArea>
+                  </div>
                 </Card>
               </div>
             </div>
@@ -252,7 +265,7 @@ export default function SingleCatalog() {
         <div className="grid h-min gap-1">
           {/* #2.1 Single Search Top Bar Section (# Results, Pagination, Sort By) */}
           <div className="z-30 hidden bg-background pt-1 md:sticky md:top-[114px] md:block">
-            <div className="flex items-center justify-between rounded-lg bg-popover px-4 py-2">
+            <div className="flex items-center justify-between rounded-lg border bg-popover px-4 py-2">
               {/* Empty div to balance the flex space */}
               <div className="w-24" />
 
@@ -270,7 +283,7 @@ export default function SingleCatalog() {
               {/* Results count with minimum width */}
               <div className="w-24 text-right">
                 <span className="whitespace-nowrap text-sm font-normal text-secondary-foreground">
-                  {numResults} results
+                  {formatResultsCount(numResults || 0)} results
                 </span>
               </div>
             </div>

--- a/components/single-search/single-catalog-item.tsx
+++ b/components/single-search/single-catalog-item.tsx
@@ -95,7 +95,7 @@ const SingleCatalogItem = ({ product }: Props) => {
               product.name
             } ${
               product.collector_number ? `(${product.collector_number})` : ''
-            }`}</h3>
+            } ${product.printing ? `[${product.printing}]` : ''}`}</h3>
             {product.quantity && (
               <p className="text-xs">{product.quantity} in stock</p>
             )}
@@ -124,13 +124,7 @@ const SingleCatalogItem = ({ product }: Props) => {
                 {findVendorNameByCode(product.vendor)}
               </div>
             </div>
-            <Badge
-              className={` mt-2 w-min ${
-                product.finish ? 'bg-foil bg-cover bg-center' : ''
-              }`}
-            >
-              {product.condition}
-            </Badge>
+            <Badge className={`mt-2 w-min`}>{product.condition}</Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Purpose: Various minor ui adjustments.

- Added missing borders
- Fixed filter section padding
- Fixed single search nav bar and search results breakpoints (both would show at the same time in a specific breakpoint)
- Replaced foil field usage with printing
- Appended the printing of a card at the end of the title for single seach result cards
- Removed foiling highlight on the condition badge since we use printing and it doesnt necessarily mean its a foil. for example 1st edition printings for pokemon cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results counts now use "k" notation for thousands (e.g., 1.5k).
  * Filter sections in search toolbars and sidebars are now scrollable for easier navigation.

* **Bug Fixes**
  * Improved keyboard navigation in the search bar, ensuring selected autocomplete suggestions are properly handled on 'Enter'.
  * Enhanced text wrapping and layout in filter options to prevent overflow and improve responsiveness.

* **Style**
  * Added borders to top bar sections in catalog views for clearer separation.
  * Adjusted navigation bar visibility to better support medium screen sizes.
  * Simplified and improved display of product titles and conditions in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->