### PR TITLE
add debounce to sealed search hook

### DIFF
--- a/components/navigation/search-bars/sealed-search-bar.tsx
+++ b/components/navigation/search-bars/sealed-search-bar.tsx
@@ -62,6 +62,7 @@ export default function SealedSearchBar({
 
   // Handle search button click
   const handleSearch = () => {
+    setSearchTerm(searchTerm);
     clearFilters();
     refetch();
     trackSearch('sealed', searchTerm, productCategory);


### PR DESCRIPTION
purpose: minimize calls to our catalog api since it was triggering on every input change on every keystroke. added a debounce of 500ms to the sealed query hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debounced search for sealed products: results update after a brief pause while typing, reducing unnecessary requests and improving responsiveness.

* **Bug Fixes**
  * Ensured the entered search term is consistently applied when starting a search, so results and filters accurately reflect the query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->