### PR TITLE
migrating buylists service into core api

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,3 @@
 NEXT_PUBLIC_AUTOCOMPLETE_URL=http://localhost/autocompleter
 NEXT_PUBLIC_PAYMENT_URL=http://localhost/payment
-NEXT_PUBLIC_BUYLISTS_URL=http://localhost/buylists
 ENV=production

--- a/hooks/useCartItems.ts
+++ b/hooks/useCartItems.ts
@@ -21,7 +21,7 @@ export function useCartItems(cartId: number | undefined) {
       if (!cartId) return [];
       try {
         const response = await axiosInstance.get(
-          `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${cartId}/cards`
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${cartId}/cards`
         );
         if (response.status === 200) {
           return response.data.items;
@@ -46,7 +46,7 @@ export function useCartItems(cartId: number | undefined) {
       quantity: number;
     }) => {
       const response = await axiosInstance.put(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${cartId}/cards`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${cartId}/cards`,
         { ...item, quantity }
       );
       return response.data;

--- a/hooks/useUserCarts.ts
+++ b/hooks/useUserCarts.ts
@@ -24,7 +24,7 @@ export function useUserCarts() {
     queryFn: async () => {
       try {
         const response = await axiosInstance.get(
-          `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts`
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts`
         );
         if (response.status === 200) {
           return response.data.carts;
@@ -42,7 +42,7 @@ export function useUserCarts() {
   const createCartMutation = useMutation({
     mutationFn: async (cartName: string) => {
       const response = await axiosInstance.post(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts`,
         { cartName }
       );
       if (response.status !== 201) {
@@ -56,7 +56,7 @@ export function useUserCarts() {
         await queryClient.invalidateQueries({ queryKey: CARTS_QUERY_KEY });
 
         const response = await axiosInstance.get(
-          `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts`
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts`
         );
 
         const newCart = response.data.carts.find(
@@ -79,7 +79,7 @@ export function useUserCarts() {
   const deleteCartMutation = useMutation({
     mutationFn: async (cartId: number) => {
       await axiosInstance.delete(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${cartId}`
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${cartId}`
       );
     },
     onSuccess: () => {
@@ -94,7 +94,7 @@ export function useUserCarts() {
   const renameCartMutation = useMutation({
     mutationFn: async ({ id, name }: IBuylistCart) => {
       const response = await axiosInstance.patch(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${id}`,
         { cartName: name.trim() }
       );
       return { success: true, message: response.data.message, id };
@@ -124,7 +124,7 @@ export function useUserCarts() {
       queryFn: async () => {
         if (!currentCartId) return null;
         const response = await axiosInstance.get(
-          `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${currentCartId}`
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${currentCartId}`
         );
         return response.data;
       },

--- a/stores/useBuylistStore.ts
+++ b/stores/useBuylistStore.ts
@@ -201,7 +201,7 @@ const useBuyListStore = create<BuyListState>((set, get) => ({
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       const response = await axiosInstance.get(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${cartId}/checkouts`
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${cartId}/checkouts`
       );
       if (response.status === 200) {
         const storeBreakdowns = response.data.data.storeBreakdowns;
@@ -242,7 +242,7 @@ const useBuyListStore = create<BuyListState>((set, get) => ({
 
     try {
       const response = await axiosInstance.post(
-        `${process.env.NEXT_PUBLIC_BUYLISTS_URL}/v2/carts/${currentCartId}/submit`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/buylists/carts/${currentCartId}/submit`,
         {
           paymentType,
           store: selectedStoreForReview


### PR DESCRIPTION
Purpose: Replacing the dedicated buylists service with the core api URL. You can push this to main in conjunction with the backend PR labeled SNAP-292